### PR TITLE
Fixed spelling on exit message

### DIFF
--- a/software/script/chameleon_cli_main.py
+++ b/software/script/chameleon_cli_main.py
@@ -164,7 +164,7 @@ class ChameleonCLI:
                 continue
 
             if cmd_str == "exit":
-                print("Bye, thanks for you.  ^.^ ")
+                print("Bye, thank you.  ^.^ ")
                 sys.exit(996)
 
             # parse cmd


### PR DESCRIPTION
Changed the exit message from "Bye, thanks for you.  ^.^ " to "Bye, thank you.  ^.^ ", which is a neater message.