### PR TITLE
Fixed Porxgrind typo

### DIFF
--- a/firmware/application/src/sdk_config.h
+++ b/firmware/application/src/sdk_config.h
@@ -6528,7 +6528,7 @@
 // <i> Setting string to NULL disables that string.
 // <i> The order of manufacturer names must be the same like in @ref APP_USBD_STRINGS_LANGIDS.
 #ifndef APP_USBD_STRINGS_MANUFACTURER
-#define APP_USBD_STRINGS_MANUFACTURER APP_USBD_STRING_DESC("Porxgrind")
+#define APP_USBD_STRINGS_MANUFACTURER APP_USBD_STRING_DESC("Proxgrind")
 #endif
 
 // </e>


### PR DESCRIPTION
Fixed the USB descriptor typo from Porxgrind to Proxgrind

Im a typo developer ;) 