### PR TITLE
This *should* autodedect the chameleons port if none is supplied

### DIFF
--- a/software/.gitignore
+++ b/software/.gitignore
@@ -5,4 +5,4 @@ script/__pycache__
 # Ignore the compilers output folder
 src/out
 # Ignore the compiled scripts
-script/
+script/*.pyc

--- a/software/script/chameleon_cli_unit.py
+++ b/software/script/chameleon_cli_unit.py
@@ -5,6 +5,7 @@ import argparse
 import colorama
 import timeit
 import sys
+import serial.tools.list_ports
 
 import chameleon_com
 import chameleon_cmd
@@ -195,14 +196,10 @@ class HWConnect(BaseCLIUnit):
         try:
             if args.port is None: # Chameleon Autodedect if no port is supplied
                 # loop through all ports and find chameleon
-                for port in chameleon_com.get_all_ports():
-                    self.device_com.open(port)
-                    resp = self.cmd_standard.get_device_info()
-                    if resp.status == chameleon_status.Device.HF_TAG_OK: # AFAIK Pyserial has no option to get USB PID/VID, would be a better solution than connecting to ever port
-                        print(f"Chameleon found on port {port}") # If it returns the expected awnser, were done
-                        args.port = port
+                for port in serial.tools.list_ports.comports():
+                    if port.manufacturer.startswith("Proxgrind") and port.description.startswith("Chameleon"):
+                        args.port = port.device
                         break
-                    self.device_com.close()
                 if args.port is None: # If no chameleon was found, exit
                     print("Chameleon not found, please connect the device or try connecting manually with the -p flag.")
                     return


### PR DESCRIPTION
This _should_ autodedect the chameleons port (in hw connect) if none is supplied, has to be tested though, cant do it myself, because i dont own the hardware _yet_.