### PR TITLE
Generate DFU packages in CI

### DIFF
--- a/.github/workflows/firmware.yml
+++ b/.github/workflows/firmware.yml
@@ -52,9 +52,26 @@ jobs:
         env:
           repo: ${{ github.repository }}
         run: |
-          docker run --rm -v ${PWD}/firmware:/workdir -e CURRENT_DEVICE_TYPE=${{ matrix.device_type }} ghcr.io/${repo,,}-fw-builder@${{ needs.build_fw_builder.outputs.image_hash }} ./build.sh
+          docker run --rm -v ${PWD}:/workdir -e CURRENT_DEVICE_TYPE=${{ matrix.device_type }} ghcr.io/${repo,,}-fw-builder@${{ needs.build_fw_builder.outputs.image_hash }} firmware/build.sh
       - name: Upload built binaries
         uses: actions/upload-artifact@v3
         with:
           name: ${{ matrix.device_type }}-firmware
-          path: firmware/objects/*.hex 
+          path: firmware/objects/*.hex
+      - name: Unzip dfu images
+        run: |
+          sudo chown -R $USER:$USER firmware/objects
+          mkdir firmware/objects/dfu-app
+          mkdir firmware/objects/dfu-full
+          unzip firmware/objects/dfu-app.zip -d firmware/objects/dfu-app
+          unzip firmware/objects/dfu-full.zip -d firmware/objects/dfu-full
+      - name: Upload dfu app image
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ matrix.device_type }}-dfu-app
+          path: firmware/objects/dfu-app/*
+      - name: Upload dfu full image
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ matrix.device_type }}-dfu-full
+          path: firmware/objects/dfu-full/*

--- a/firmware/build.sh
+++ b/firmware/build.sh
@@ -2,6 +2,25 @@
 
 # Partially based on informations from https://github.com/RfidResearchGroup/ChameleonUltra/issues/16
 
+if [[ $BASH_SOURCE = */* ]]; then
+  cd -- "${BASH_SOURCE%/*}/" || exit
+fi
+
+softdevice=s140
+softdevice_version=7.2.0
+softdevice_id=0x0100
+
+
+# TODO: find a way to manage this automatically, I don't want to rely on action build #.
+application_version=1
+bootloader_version=1
+
+declare -A device_type_to_hw_version=( ["ultra"]="0" ["lite"]="1" )
+
+device_type=${CURRENT_DEVICE_TYPE:-ultra}
+hw_version=${device_type_to_hw_version[$device_type]}
+echo "Building firmware for $device_type (hw_version=$hw_version)"
+
 set -xe
 
 (
@@ -16,6 +35,22 @@ set -xe
 
 (
   cd objects
-  nrfutil settings generate --family NRF52840 --application application.hex --application-version 1 --bootloader-version 1 --bl-settings-version 2 settings.hex
-  mergehex --merge bootloader.hex settings.hex application.hex ../nrf52_sdk/components/softdevice/s140/hex/s140_nrf52_7.2.0_softdevice.hex --output project.hex
+  nrfutil settings generate --family NRF52840 \
+    --application application.hex --application-version $application_version \
+    --bootloader-version $bootloader_version --bl-settings-version 2 settings.hex
+  mergehex --merge bootloader.hex settings.hex --output bootloader_merged.hex
+  mergehex --merge bootloader_merged.hex application.hex \
+    ../nrf52_sdk/components/softdevice/${softdevice}/hex/${softdevice}_nrf52_${softdevice_version}_softdevice.hex --output fullimage.hex
+  nrfutil pkg generate \
+    --application application.hex --application-version $application_version \
+    --bootloader bootloader_merged.hex --bootloader-version $bootloader_version \
+    --softdevice ../nrf52_sdk/components/softdevice/${softdevice}/hex/${softdevice}_nrf52_${softdevice_version}_softdevice.hex --sd-id ${softdevice_id} \
+    --sd-req ${softdevice_id} --hw-version $hw_version \
+    --key-file ../../resource/dfu_key/chameleon.pem \
+    dfu-full.zip
+  nrfutil pkg generate \
+    --application application.hex --application-version $application_version \
+    --sd-req ${softdevice_id} --hw-version $hw_version \
+    --key-file ../../resource/dfu_key/chameleon.pem \
+    dfu-app.zip
 )


### PR DESCRIPTION
Two DFU packages are generated per target:
- `$target-dfu-app.zip`: only application is flashed
- `$target-dfu-full.zip`: bootloader, softdevice and application are flashed