### PR TITLE
client: don't let recv thread crashing after hw dfu

### DIFF
--- a/software/script/chameleon_cli_unit.py
+++ b/software/script/chameleon_cli_unit.py
@@ -5,6 +5,7 @@ import argparse
 import colorama
 import timeit
 import sys
+import time
 import serial.tools.list_ports
 
 import chameleon_com
@@ -973,3 +974,5 @@ class HWDFU(DeviceRequiredUnit):
         # 我们判断是否成功进入USB，只需要判断USB是否变成DFU设备的VID和PID即可，
         # 同时我们记得确认设备的信息，一致时才是同一个设备。
         print(" - Enter success @.@~")
+        # let time for comm thread to send dfu cmd and close port
+        time.sleep(0.1)

--- a/software/script/chameleon_cmd.py
+++ b/software/script/chameleon_cmd.py
@@ -416,7 +416,7 @@ class BaseChameleonCMD:
             重启进入DFU模式(bootloader)
         :return:
         """
-        return self.device.send_cmd_auto(DATA_CMD_ENTER_BOOTLOADER, 0x00, None)
+        return self.device.send_cmd_auto(DATA_CMD_ENTER_BOOTLOADER, 0x00, close=True)
 
 
 class NegativeResponseError(Exception):

--- a/software/script/chameleon_com.py
+++ b/software/script/chameleon_com.py
@@ -225,6 +225,7 @@ class ChameleonCom:
             task = self.send_data_queue.get()
             task_cmd = task['cmd']
             task_timeout = task['timeout']
+            task_close = task['close']
             # register to wait map
             if 'callback' in task and callable(task['callback']):
                 self.wait_response_map[task_cmd] = {
@@ -248,6 +249,9 @@ class ChameleonCom:
                 break
             # update queue status
             self.send_data_queue.task_done()
+            # disconnect if DFU command has been sent
+            if task_close:
+                self.close()
 
     def thread_check_timeout(self):
         """
@@ -287,7 +291,7 @@ class ChameleonCom:
         frame.append(self.lrc_calc(frame))
         return frame
 
-    def send_cmd_auto(self, cmd: int, status: int, data: bytearray = None, callback=None, timeout: int = 3):
+    def send_cmd_auto(self, cmd: int, status: int, data: bytearray = None, callback=None, timeout: int = 3, close: bool = False):
         """
             Send cmd to device
         :param timeout: wait response timeout
@@ -307,6 +311,7 @@ class ChameleonCom:
             'cmd': cmd,
             'frame': data_frame,
             'timeout': timeout,
+            'close': close,
         }
         if callable(callback):
             task['callback'] = callback


### PR DESCRIPTION
Add flag to cmd to tell to close connection nicely after having sent the cmd.
Useful e.g. for closing comm after sending `hw dfu`