### PR TITLE
Clean nrf* part of build.sh + get device address & chip id

### DIFF
--- a/firmware/application/src/app_cmd.c
+++ b/firmware/application/src/app_cmd.c
@@ -73,6 +73,12 @@ data_frame_tx_t* cmd_processor_get_device_chip_id(uint16_t cmd, uint16_t status,
     return data_frame_make(cmd, STATUS_DEVICE_SUCCESS, 8, (uint8_t*)(&chip_id[0]));
 }
 
+data_frame_tx_t* cmd_processor_get_device_address(uint16_t cmd, uint16_t status, uint16_t length, uint8_t *data) {
+    uint32_t device_address[2];
+    device_address[0] = NRF_FICR->DEVICEADDR[0];
+    device_address[1] = NRF_FICR->DEVICEADDR[1];
+    return data_frame_make(cmd, STATUS_DEVICE_SUCCESS, 6, (uint8_t*)(&device_address[0]));
+}
 
 #if defined(PROJECT_CHAMELEON_ULTRA)
 
@@ -517,6 +523,7 @@ static cmd_data_map_t m_data_cmd_map[] = {
     {    DATA_CMD_GET_DEVICE_MODE,              NULL,                        cmd_processor_get_device_mode,               NULL                   },
     {    DATA_CMD_ENTER_BOOTLOADER,             NULL,                        cmd_processor_enter_bootloader,              NULL                   },
     {    DATA_CMD_GET_DEVICE_CHIP_ID,           NULL,                        cmd_processor_get_device_chip_id,            NULL                   },
+    {    DATA_CMD_GET_DEVICE_ADDRESS,           NULL,                        cmd_processor_get_device_address,            NULL                   },
 
 #if defined(PROJECT_CHAMELEON_ULTRA)
 

--- a/firmware/application/src/data_cmd.h
+++ b/firmware/application/src/data_cmd.h
@@ -19,6 +19,7 @@
 #define DATA_CMD_SLOT_DATA_CONFIG_SAVE          (1009)
 #define DATA_CMD_ENTER_BOOTLOADER               (1010)
 #define DATA_CMD_GET_DEVICE_CHIP_ID             (1011)
+#define DATA_CMD_GET_DEVICE_ADDRESS             (1012)
 //
 // ******************************************************************
 

--- a/firmware/build.sh
+++ b/firmware/build.sh
@@ -35,22 +35,31 @@ set -xe
 
 (
   cd objects
-  nrfutil settings generate --family NRF52840 \
-    --application application.hex --application-version $application_version \
-    --bootloader-version $bootloader_version --bl-settings-version 2 settings.hex
-  mergehex --merge bootloader.hex settings.hex --output bootloader_merged.hex
-  mergehex --merge bootloader_merged.hex application.hex \
-    ../nrf52_sdk/components/softdevice/${softdevice}/hex/${softdevice}_nrf52_${softdevice_version}_softdevice.hex --output fullimage.hex
-  nrfutil pkg generate \
-    --application application.hex --application-version $application_version \
-    --bootloader bootloader_merged.hex --bootloader-version $bootloader_version \
-    --softdevice ../nrf52_sdk/components/softdevice/${softdevice}/hex/${softdevice}_nrf52_${softdevice_version}_softdevice.hex --sd-id ${softdevice_id} \
-    --sd-req ${softdevice_id} --hw-version $hw_version \
-    --key-file ../../resource/dfu_key/chameleon.pem \
+  
+  nrfutil nrf5sdk-tools pkg generate \
+    --hw-version 0 \
+    --bootloader  bootloader.hex   --bootloader-version  $bootloader_version  --key-file ../../resource/dfu_key/chameleon.pem \
+    --application application.hex  --application-version $application_version --app-boot-validation NO_VALIDATION \
+    --softdevice  ../nrf52_sdk/components/softdevice/${softdevice}/hex/${softdevice}_nrf52_${softdevice_version}_softdevice.hex --sd-req ${softdevice_id} --sd-id ${softdevice_id} --sd-boot-validation NO_VALIDATION \
     dfu-full.zip
-  nrfutil pkg generate \
-    --application application.hex --application-version $application_version \
-    --sd-req ${softdevice_id} --hw-version $hw_version \
-    --key-file ../../resource/dfu_key/chameleon.pem \
+	
+  nrfutil nrf5sdk-tools pkg generate \
+    --hw-version 0 --key-file ../../resource/dfu_key/chameleon.pem \
+    --application application.hex  --application-version $application_version --app-boot-validation NO_VALIDATION \
+    --sd-req ${softdevice_id} \
     dfu-app.zip
+
+  nrfutil nrf5sdk-tools settings generate \
+    --family NRF52840 \
+    --application application.hex --application-version $application_version \
+    --bootloader-version $bootloader_version --bl-settings-version 2 \
+    settings.hex
+
+  mergehex \
+    --merge \
+      bootloader.hex \
+      settings.hex \
+      application.hex \
+      ../nrf52_sdk/components/softdevice/${softdevice}/hex/${softdevice}_nrf52_${softdevice_version}_softdevice.hex \
+    --output fullimage.hex
 )

--- a/software/script/chameleon_cli_main.py
+++ b/software/script/chameleon_cli_main.py
@@ -56,6 +56,14 @@ class ChameleonCLI:
         self.cmd_maps = {
             'hw': {
                 'connect': new_uint(chameleon_cli_unit.HWConnect, "Connect to chameleon by serial port"),
+                'chipid': {
+                    'get': new_uint(chameleon_cli_unit.HWChipIdGet, "Get device chipset ID"),
+                    'help': "Device chipsed ID get"
+                },
+                'address': {
+                    'get': new_uint(chameleon_cli_unit.HWAddressGet, "Get device address (used with Bluetooth)"),
+                    'help': "Device address get"
+                },
                 'mode': {
                     'set': new_uint(chameleon_cli_unit.HWModeSet, "Change device mode to tag reader or tag emulator"),
                     'get': new_uint(chameleon_cli_unit.HWModeGet, "Get current device mode"),

--- a/software/script/chameleon_cli_unit.py
+++ b/software/script/chameleon_cli_unit.py
@@ -236,6 +236,24 @@ class HWModeGet(DeviceRequiredUnit):
         print(f"- Device Mode ( Tag {'Reader' if self.cmd_standard.is_reader_device_mode() else 'Emulator'} )")
 
 
+class HWChipIdGet(DeviceRequiredUnit):
+
+    def args_parser(self) -> ArgumentParserNoExit or None:
+        return None
+
+    def on_exec(self, args: argparse.Namespace):
+        print(f' - Device chip ID: ' + self.cmd_positive.get_device_chip_id())
+
+
+class HWAddressGet(DeviceRequiredUnit):
+
+    def args_parser(self) -> ArgumentParserNoExit or None:
+        return None
+
+    def on_exec(self, args: argparse.Namespace):
+        print(f' - Device address: ' + self.cmd_positive.get_device_address())
+
+
 class HF14AScan(ReaderRequiredUint):
     def args_parser(self) -> ArgumentParserNoExit or None:
         pass

--- a/software/script/chameleon_cmd.py
+++ b/software/script/chameleon_cmd.py
@@ -18,6 +18,7 @@ DATA_CMD_SLOT_DATA_CONFIG_SAVE = 1009
 
 DATA_CMD_ENTER_BOOTLOADER = 1010
 DATA_CMD_GET_DEVICE_CHIP_ID = 1011
+DATA_CMD_GET_DEVICE_ADDRESS = 1012
 
 DATA_CMD_SCAN_14A_TAG = 2000
 DATA_CMD_MF1_SUPPORT_DETECT = 2001
@@ -101,6 +102,12 @@ class BaseChameleonCMD:
         resp = self.device.send_cmd_sync(DATA_CMD_GET_DEVICE_CHIP_ID, 0x00, None)
         return resp.data.hex()
     
+    def get_device_address(self) -> str:
+        """
+            Get device address
+        """
+        resp = self.device.send_cmd_sync(DATA_CMD_GET_DEVICE_ADDRESS, 0x00, None)
+        return resp.data[::-1].hex()
     
 
     def is_reader_device_mode(self) -> bool:


### PR DESCRIPTION
This commit :
- create a new simple command in firmware and Python client : `DATA_CMD_GET_DEVICE_ADDRESS`
- expose an existing one: `DATA_CMD_GET_DEVICE_CHIP_ID`
- modify `build.sh` to generate DFU package without `bootloader_merged.hex`, `mergehex` is only used one time.