### PR TITLE
Upload DFU zip files to releases

### DIFF
--- a/.github/workflows/firmware.yml
+++ b/.github/workflows/firmware.yml
@@ -48,11 +48,6 @@ jobs:
     steps:
       - name: Check out the repo
         uses: actions/checkout@v3
-      - name: Get upload URL
-        shell: bash
-        run: |
-          upload_url=$(curl -sL https://api.github.com/repos/actions/checkout/releases/latest | jq -r '.upload_url')
-          echo UPLOAD_URL=$upload_url >> $GITHUB_ENV
       - name: Build firmware
         env:
           repo: ${{ github.repository }}

--- a/.github/workflows/firmware.yml
+++ b/.github/workflows/firmware.yml
@@ -48,6 +48,11 @@ jobs:
     steps:
       - name: Check out the repo
         uses: actions/checkout@v3
+      - name: Get upload URL
+        shell: bash
+        run: |
+          upload_url=$(curl -sL https://api.github.com/repos/actions/checkout/releases/latest | jq -r '.upload_url')
+          echo UPLOAD_URL=$upload_url >> $GITHUB_ENV
       - name: Build firmware
         env:
           repo: ${{ github.repository }}
@@ -75,3 +80,62 @@ jobs:
         with:
           name: ${{ matrix.device_type }}-dfu-full
           path: firmware/objects/dfu-full/*
+  create_release:
+    permissions: write-all
+    name: Create Pre-Release with dfu app images
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
+    needs:
+      - build_fw
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v3
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.run_number }}
+          release_name: Compiled commit ${{ github.sha }}
+          body: |
+            Auto-Generated DFU images
+          draft: false
+          prerelease: true
+      - name: Download Ultra DFU
+        uses: actions/download-artifact@v3
+        with:
+          name: ultra-dfu-app
+          path: dfu-app-artifacts
+      - name: Compress
+        run: |
+          zip --junk-paths -0 -r ./dfu-app-artifacts/dfu-app.zip ./dfu-app-artifacts/*
+      - name: Upload Ultra DFU
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./dfu-app-artifacts/dfu-app.zip
+          asset_name: ultra-dfu-app.zip
+          asset_content_type: application/zip
+      - name: Clear
+        run: |
+          rm -rf ./dfu-app-artifacts/
+      - name: Download Lite DFU
+        uses: actions/download-artifact@v3
+        with:
+          name: lite-dfu-app
+          path: dfu-app-artifacts
+      - name: Compress
+        run: |
+          zip --junk-paths -0 -r ./dfu-app-artifacts/dfu-app.zip ./dfu-app-artifacts/*
+      - name: Upload Lite DFU
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./dfu-app-artifacts/dfu-app.zip
+          asset_name: lite-dfu-app.zip
+          asset_content_type: application/zip


### PR DESCRIPTION
GitHub doesn't allow unauthorized users to download artifacts from actions. This PR will allow GitHub Actions to publish releases (pre-release) with .zip files for DFU (so users can flash it without GitHub account)

Required for https://github.com/GameTec-live/ChameleonUltraGUI/pull/52