### PR TITLE
Add animation modes support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .idea/
 .vscode/
 .vs/
+
+.DS_Store

--- a/firmware/application/Makefile
+++ b/firmware/application/Makefile
@@ -11,6 +11,7 @@ SRC_FILES += \
   $(PROJ_DIR)/app_cmd.c \
   $(PROJ_DIR)/ble_main.c \
   $(PROJ_DIR)/rfid_main.c \
+  $(PROJ_DIR)/settings.c \
   $(PROJ_DIR)/usb_main.c \
   $(PROJ_DIR)/rgb_marquee.c \
   $(PROJ_DIR)/bsp/bsp_delay.c \

--- a/firmware/application/src/app_cmd.c
+++ b/firmware/application/src/app_cmd.c
@@ -86,6 +86,12 @@ data_frame_tx_t* cmd_processor_save_settings(uint16_t cmd, uint16_t status, uint
     return data_frame_make(cmd, status, 0, NULL);
 }
 
+data_frame_tx_t* cmd_processor_reset_settings(uint16_t cmd, uint16_t status, uint16_t length, uint8_t *data) {
+    settings_init_config();
+    status = settings_save_config();
+    return data_frame_make(cmd, status, 0, NULL);
+}
+
 data_frame_tx_t* cmd_processor_set_animation_mode(uint16_t cmd, uint16_t status, uint16_t length, uint8_t *data) {
     if (length == 1) {
         settings_set_animation_config(data[0]);
@@ -546,6 +552,7 @@ static cmd_data_map_t m_data_cmd_map[] = {
     {    DATA_CMD_GET_DEVICE_CHIP_ID,           NULL,                        cmd_processor_get_device_chip_id,            NULL                   },
     {    DATA_CMD_GET_DEVICE_ADDRESS,           NULL,                        cmd_processor_get_device_address,            NULL                   },
     {    DATA_CMD_SAVE_SETTINGS,                NULL,                        cmd_processor_save_settings,                 NULL                   },
+    {    DATA_CMD_RESET_SETTINGS,               NULL,                        cmd_processor_reset_settings,                NULL                   },
     {    DATA_CMD_SET_ANIMATION_MODE,           NULL,                        cmd_processor_set_animation_mode,            NULL                   },
     {    DATA_CMD_GET_ANIMATION_MODE,           NULL,                        cmd_processor_get_animation_mode,            NULL                   },
 

--- a/firmware/application/src/app_cmd.c
+++ b/firmware/application/src/app_cmd.c
@@ -12,6 +12,7 @@
 #include "app_status.h"
 #include "tag_persistence.h"
 #include "nrf_pwr_mgmt.h"
+#include "settings.h"
 
 
 #define NRF_LOG_MODULE_NAME app_cmd
@@ -78,6 +79,26 @@ data_frame_tx_t* cmd_processor_get_device_address(uint16_t cmd, uint16_t status,
     device_address[0] = NRF_FICR->DEVICEADDR[0];
     device_address[1] = NRF_FICR->DEVICEADDR[1];
     return data_frame_make(cmd, STATUS_DEVICE_SUCCESS, 6, (uint8_t*)(&device_address[0]));
+}
+
+data_frame_tx_t* cmd_processor_save_settings(uint16_t cmd, uint16_t status, uint16_t length, uint8_t *data) {
+    status = settings_save_config();
+    return data_frame_make(cmd, status, 0, NULL);
+}
+
+data_frame_tx_t* cmd_processor_set_animation_mode(uint16_t cmd, uint16_t status, uint16_t length, uint8_t *data) {
+    if (length == 1) {
+        settings_set_animation_config(data[0]);
+    }
+    else {
+        status = STATUS_PAR_ERR; 
+    }
+    return data_frame_make(cmd, status, 0, NULL);
+}
+
+data_frame_tx_t* cmd_processor_get_animation_mode(uint16_t cmd, uint16_t status, uint16_t length, uint8_t *data) {
+    uint8_t animation_mode = settings_get_animation_config();
+    return data_frame_make(cmd, STATUS_DEVICE_SUCCESS, 1, (uint8_t *)(&animation_mode));
 }
 
 #if defined(PROJECT_CHAMELEON_ULTRA)
@@ -524,6 +545,9 @@ static cmd_data_map_t m_data_cmd_map[] = {
     {    DATA_CMD_ENTER_BOOTLOADER,             NULL,                        cmd_processor_enter_bootloader,              NULL                   },
     {    DATA_CMD_GET_DEVICE_CHIP_ID,           NULL,                        cmd_processor_get_device_chip_id,            NULL                   },
     {    DATA_CMD_GET_DEVICE_ADDRESS,           NULL,                        cmd_processor_get_device_address,            NULL                   },
+    {    DATA_CMD_SAVE_SETTINGS,                NULL,                        cmd_processor_save_settings,                 NULL                   },
+    {    DATA_CMD_SET_ANIMATION_MODE,           NULL,                        cmd_processor_set_animation_mode,            NULL                   },
+    {    DATA_CMD_GET_ANIMATION_MODE,           NULL,                        cmd_processor_get_animation_mode,            NULL                   },
 
 #if defined(PROJECT_CHAMELEON_ULTRA)
 

--- a/firmware/application/src/app_main.c
+++ b/firmware/application/src/app_main.c
@@ -359,6 +359,8 @@ static void check_wakeup_src(void) {
             ledblink2(color, !dir, dir ? slot : 7 - slot);
         } else if (animation_config == SettingsAnimationModeMinimal) {
             ledblink2(color, !dir, dir ? slot : 7 - slot);
+        } else {
+            set_slot_light_color(color);
         }
 
         // The indicator of the current card slot lights up at the end of the animation

--- a/firmware/application/src/app_main.c
+++ b/firmware/application/src/app_main.c
@@ -36,6 +36,8 @@ NRF_LOG_MODULE_REGISTER();
 #include "usb_main.h"
 #include "rgb_marquee.h"
 
+#include "settings.h"
+
 
 // Defining soft timers
 APP_TIMER_DEF(m_button_check_timer); // Timer for button debounce
@@ -219,22 +221,25 @@ static void system_off_enter(void) {
         for (uint8_t i = 0; i < RGB_LIST_NUM; i++) {
             nrf_gpio_pin_clear(p_led_array[i]);
         }
-        uint8_t slot = tag_emulation_get_slot();
-        // Power off animation
-        uint8_t dir = slot > 3 ? 1 : 0;
-        uint8_t color = get_color_by_slot(slot);
-        if (m_reset_source & (NRF_POWER_RESETREAS_NFC_MASK | NRF_POWER_RESETREAS_LPCOMP_MASK)) {
-            if (m_reset_source & NRF_POWER_RESETREAS_NFC_MASK) {
-                color = 1;
-            } else {
-                color = 2;
+        uint8_t animation_config = settings_get_animation_config();
+        if (animation_config == SETTINGS_ANIMATION_FULL) {
+            uint8_t slot = tag_emulation_get_slot();
+            // Power off animation
+            uint8_t dir = slot > 3 ? 1 : 0;
+            uint8_t color = get_color_by_slot(slot);
+            if (m_reset_source & (NRF_POWER_RESETREAS_NFC_MASK | NRF_POWER_RESETREAS_LPCOMP_MASK)) {
+                if (m_reset_source & NRF_POWER_RESETREAS_NFC_MASK) {
+                    color = 1;
+                } else {
+                    color = 2;
+                }
             }
+            ledblink5(color, slot, dir ? 7 : 0);
+            ledblink4(color, dir, 7, 99, 75);
+            ledblink4(color, !dir, 7, 75, 50);
+            ledblink4(color, dir, 7, 50, 25);
+            ledblink4(color, !dir, 7, 25, 0);
         }
-        ledblink5(color, slot, dir ? 7 : 0);
-        ledblink4(color, dir, 7, 99, 75);
-        ledblink4(color, !dir, 7, 75, 50);
-        ledblink4(color, dir, 7, 50, 25);
-        ledblink4(color, !dir, 7, 25, 0);
         rgb_marquee_stop();
     }
 
@@ -346,9 +351,17 @@ static void check_wakeup_src(void) {
         advertising_start(); // Turn on Bluetooth radio
 
         // Button wake-up boot animation
-        ledblink2(color, !dir, 11);
-        ledblink2(color, dir, 11);
-        ledblink2(color, !dir, dir ? slot : 7 - slot);
+        uint8_t animation_config = settings_get_animation_config();
+        if (animation_config == SETTINGS_ANIMATION_FULL)
+        {
+            ledblink2(color, !dir, 11);
+            ledblink2(color, dir, 11);
+            ledblink2(color, !dir, dir ? slot : 7 - slot);
+        }
+        else if (animation_config == SETTINGS_ANIMATION_MINIMAL) {
+            ledblink2(color, !dir, dir ? slot : 7 - slot);
+        }
+
         // The indicator of the current card slot lights up at the end of the animation
         light_up_by_slot();
 
@@ -374,8 +387,11 @@ static void check_wakeup_src(void) {
         // 当前是模拟卡事件唤醒系统，我们可以让场强灯先亮起来
         TAG_FIELD_LED_ON();
 
-        // In the case of field wake-up, only one round of RGB is swept as the power-on animation
-        ledblink2(color, !dir, dir ? slot : 7 - slot);
+        uint8_t animation_config = settings_get_animation_config();
+        if (animation_config == SETTINGS_ANIMATION_FULL) {
+            // In the case of field wake-up, only one round of RGB is swept as the power-on animation
+            ledblink2(color, !dir, dir ? slot : 7 - slot);
+        }
         set_slot_light_color(color);
         light_up_by_slot();
 
@@ -516,6 +532,8 @@ int main(void) {
     ble_slave_init();         // Bluetooth protocol stack initialization
     tag_emulation_init();     // Analog card initialization
     rgb_marquee_init();       // Light effect initialization
+
+    settings_load_config();   // Load settings from flash
 
     // cmd callback register
     on_data_frame_complete(on_data_frame_received);

--- a/firmware/application/src/app_main.c
+++ b/firmware/application/src/app_main.c
@@ -222,7 +222,7 @@ static void system_off_enter(void) {
             nrf_gpio_pin_clear(p_led_array[i]);
         }
         uint8_t animation_config = settings_get_animation_config();
-        if (animation_config == SETTINGS_ANIMATION_FULL) {
+        if (animation_config == SettingsAnimationModeFull) {
             uint8_t slot = tag_emulation_get_slot();
             // Power off animation
             uint8_t dir = slot > 3 ? 1 : 0;
@@ -352,13 +352,12 @@ static void check_wakeup_src(void) {
 
         // Button wake-up boot animation
         uint8_t animation_config = settings_get_animation_config();
-        if (animation_config == SETTINGS_ANIMATION_FULL)
+        if (animation_config == SettingsAnimationModeFull)
         {
             ledblink2(color, !dir, 11);
             ledblink2(color, dir, 11);
             ledblink2(color, !dir, dir ? slot : 7 - slot);
-        }
-        else if (animation_config == SETTINGS_ANIMATION_MINIMAL) {
+        } else if (animation_config == SettingsAnimationModeMinimal) {
             ledblink2(color, !dir, dir ? slot : 7 - slot);
         }
 
@@ -388,7 +387,7 @@ static void check_wakeup_src(void) {
         TAG_FIELD_LED_ON();
 
         uint8_t animation_config = settings_get_animation_config();
-        if (animation_config == SETTINGS_ANIMATION_FULL) {
+        if (animation_config == SettingsAnimationModeFull) {
             // In the case of field wake-up, only one round of RGB is swept as the power-on animation
             ledblink2(color, !dir, dir ? slot : 7 - slot);
         }

--- a/firmware/application/src/data_cmd.h
+++ b/firmware/application/src/data_cmd.h
@@ -21,8 +21,9 @@
 #define DATA_CMD_GET_DEVICE_CHIP_ID             (1011)
 #define DATA_CMD_GET_DEVICE_ADDRESS             (1012)
 #define DATA_CMD_SAVE_SETTINGS                  (1013)
-#define DATA_CMD_SET_ANIMATION_MODE             (1014)
-#define DATA_CMD_GET_ANIMATION_MODE             (1015)
+#define DATA_CMD_RESET_SETTINGS                 (1014)
+#define DATA_CMD_SET_ANIMATION_MODE             (1015)
+#define DATA_CMD_GET_ANIMATION_MODE             (1016)
 //
 // ******************************************************************
 

--- a/firmware/application/src/data_cmd.h
+++ b/firmware/application/src/data_cmd.h
@@ -20,6 +20,9 @@
 #define DATA_CMD_ENTER_BOOTLOADER               (1010)
 #define DATA_CMD_GET_DEVICE_CHIP_ID             (1011)
 #define DATA_CMD_GET_DEVICE_ADDRESS             (1012)
+#define DATA_CMD_SAVE_SETTINGS                  (1013)
+#define DATA_CMD_SET_ANIMATION_MODE             (1014)
+#define DATA_CMD_GET_ANIMATION_MODE             (1015)
 //
 // ******************************************************************
 

--- a/firmware/application/src/rfid/nfctag/tag_emulation.c
+++ b/firmware/application/src/rfid/nfctag/tag_emulation.c
@@ -3,6 +3,7 @@
 #include "lf_tag_em.h"
 #include "nfc_mf1.h"
 #include "nfc_ntag.h"
+#include "fds_ids.h"
 #include "fds_util.h"
 #include "tag_emulation.h"
 #include "tag_persistence.h"

--- a/firmware/application/src/rfid/nfctag/tag_emulation.h
+++ b/firmware/application/src/rfid/nfctag/tag_emulation.h
@@ -5,12 +5,11 @@
 #include <stdint.h>
 #include <stdbool.h>
 
+#include "utils.h"
 #include "tag_base_type.h"
 
 // 最多八张卡槽
 #define TAG_MAX_SLOT_NUM    8
-// u32 size align.
-#define ALIGN_U32  __attribute__((aligned(4)))
 
 extern bool g_is_tag_emulating;
 

--- a/firmware/application/src/rfid/nfctag/tag_persistence.c
+++ b/firmware/application/src/rfid/nfctag/tag_persistence.c
@@ -1,5 +1,5 @@
 #include "tag_persistence.h"
-
+#include "fds_ids.h"
 
 #define NRF_LOG_MODULE_NAME tag_persistence
 #include "nrf_log.h"

--- a/firmware/application/src/rfid/nfctag/tag_persistence.h
+++ b/firmware/application/src/rfid/nfctag/tag_persistence.h
@@ -5,27 +5,6 @@
 #include "tag_base_type.h"
 
 
-/*
- * 卡槽配置，只有一份，一致即可
- */
-#define FDS_CONFIG_RECORD_FILE_KEY   0x1066
-#define FDS_CONFIG_RECORD_FILE_ID    0x1066
-
-/*
- * 每个卡槽有高低频两种数据，其中key是跟卡槽走的，而id+n就等于数据索引，固定某个索引为指定类型即可
- * 每个slot的file_key都不一样
- * 每个slot有两种类型的卡片，因此有两个数据ID（当前）
- */
-#define FDS_SLOT_TAG_DUMP_FILE_KEY   0x1067
-#define FDS_SLOT_TAG_DUMP_FILE_ID    0x1067
-
-/*
- * 每个卡槽有高低频两种数据，因此卡槽的昵称也要有两种，其中key是跟卡槽走的，而id+n就等于数据索引，固定某个索引为指定类型即可
- */
-#define FDS_SLOT_TAG_NICK_NAME_KEY   0x1068
-#define FDS_SLOT_TAG_NICK_NAME_ID    0x1068
-
-
 typedef struct {
     uint16_t key;
     uint16_t id;

--- a/firmware/application/src/settings.c
+++ b/firmware/application/src/settings.c
@@ -33,19 +33,19 @@ uint8_t settings_save_config(void)
     uint16_t new_calc_crc;
     calc_14a_crc_lut((uint8_t *)&config, sizeof(config), (uint8_t *)&new_calc_crc);
     if (new_calc_crc != m_config_crc) {    // Before saving, make sure that the configuration has changed
-        NRF_LOG_INFO("Save tag slot config start.");
+        NRF_LOG_INFO("Save config start.");
         bool ret = fds_write_sync(FDS_SETTINGS_ID, FDS_SETTINGS_KEY, sizeof(config) / 4, (uint8_t *)&config);
         if (ret) {
-            NRF_LOG_INFO("Save tag slot config success.");
+            NRF_LOG_INFO("Save config success.");
             m_config_crc = new_calc_crc; // store new CRC so we know that we've updated the configuration
         }
         else
         {
-            NRF_LOG_ERROR("Save tag slot config error.");
+            NRF_LOG_ERROR("Save config error.");
             return STATUS_FLASH_WRITE_FAIL;
         }
     } else {
-        NRF_LOG_INFO("Tag slot config no change.");
+        NRF_LOG_INFO("Config no change.");
     }
 
     return STATUS_DEVICE_SUCCESS;

--- a/firmware/application/src/settings.c
+++ b/firmware/application/src/settings.c
@@ -53,11 +53,10 @@ uint8_t settings_save_config(void)
 
 uint8_t settings_get_animation_config()
 {
-    return config & 0x3;
+    return config.animation_config;
 }
 
 void settings_set_animation_config(uint8_t value)
 {
-    config &= ~(0x3);
-    config |= value;
+    config.animation_config = value;
 }

--- a/firmware/application/src/settings.c
+++ b/firmware/application/src/settings.c
@@ -34,7 +34,7 @@ uint8_t settings_save_config(void)
     calc_14a_crc_lut((uint8_t *)&config, sizeof(config), (uint8_t *)&new_calc_crc);
     if (new_calc_crc != m_config_crc) {    // Before saving, make sure that the configuration has changed
         NRF_LOG_INFO("Save tag slot config start.");
-        bool ret = fds_write_sync(FDS_CONFIG_RECORD_FILE_ID, FDS_CONFIG_RECORD_FILE_KEY, sizeof(config) / 4, (uint8_t *)&config);
+        bool ret = fds_write_sync(FDS_SETTINGS_ID, FDS_SETTINGS_KEY, sizeof(config) / 4, (uint8_t *)&config);
         if (ret) {
             NRF_LOG_INFO("Save tag slot config success.");
             m_config_crc = new_calc_crc; // store new CRC so we know that we've updated the configuration

--- a/firmware/application/src/settings.c
+++ b/firmware/application/src/settings.c
@@ -1,0 +1,63 @@
+#include <stdbool.h>
+#include "crc_utils.h"
+#include "app_status.h"
+#include "settings.h"
+#include "fds_ids.h"
+#include "fds_util.h"
+
+#define NRF_LOG_MODULE_NAME settings
+#include "nrf_log.h"
+#include "nrf_log_ctrl.h"
+#include "nrf_log_default_backends.h"
+NRF_LOG_MODULE_REGISTER();
+
+static settings_data_t config;
+
+static uint16_t m_config_crc;
+
+void settings_load_config(void)
+{
+    bool ret = fds_read_sync(FDS_SETTINGS_ID, FDS_SETTINGS_KEY, sizeof(config), (uint8_t *)&config);
+    if (ret) {
+        // After the reading is complete, we first save a copy of the current CRC, which can be used as a reference for comparison of changes when saving later
+        calc_14a_crc_lut((uint8_t *)&config, sizeof(config), (uint8_t *)&m_config_crc);
+        NRF_LOG_INFO("Load config done.");
+    } else {
+        NRF_LOG_INFO("config no exists.");
+    }
+}
+
+uint8_t settings_save_config(void)
+{
+    // We are saving the configuration, we need to calculate the crc code of the current configuration to judge whether the following data is updated
+    uint16_t new_calc_crc;
+    calc_14a_crc_lut((uint8_t *)&config, sizeof(config), (uint8_t *)&new_calc_crc);
+    if (new_calc_crc != m_config_crc) {    // Before saving, make sure that the configuration has changed
+        NRF_LOG_INFO("Save tag slot config start.");
+        bool ret = fds_write_sync(FDS_CONFIG_RECORD_FILE_ID, FDS_CONFIG_RECORD_FILE_KEY, sizeof(config) / 4, (uint8_t *)&config);
+        if (ret) {
+            NRF_LOG_INFO("Save tag slot config success.");
+            m_config_crc = new_calc_crc; // store new CRC so we know that we've updated the configuration
+        }
+        else
+        {
+            NRF_LOG_ERROR("Save tag slot config error.");
+            return STATUS_FLASH_WRITE_FAIL;
+        }
+    } else {
+        NRF_LOG_INFO("Tag slot config no change.");
+    }
+
+    return STATUS_DEVICE_SUCCESS;
+}
+
+uint8_t settings_get_animation_config()
+{
+    return config & 0x3;
+}
+
+void settings_set_animation_config(uint8_t value)
+{
+    config &= ~(0x3);
+    config |= value;
+}

--- a/firmware/application/src/settings.c
+++ b/firmware/application/src/settings.c
@@ -15,29 +15,84 @@ static settings_data_t config;
 
 static uint16_t m_config_crc;
 
+static void update_config_crc(void)
+{
+    calc_14a_crc_lut((uint8_t *)&config, sizeof(config), (uint8_t *)&m_config_crc);
+}
+
+static bool config_did_change(void)
+{
+    uint16_t new_calc_crc;
+    calc_14a_crc_lut((uint8_t *)&config, sizeof(config), (uint8_t *)&new_calc_crc);
+    return new_calc_crc != m_config_crc;
+}
+
+void settings_init_config(void)
+{
+    config.version = SETTINGS_CURRENT_VERSION;
+    config.animation_config = SettingsAnimationModeFull;
+}
+
+void settings_migrate(void)
+{
+    switch (config.version) {
+        case 0:
+            NRF_LOG_ERROR("Unexpected configuration version detected!");
+            settings_init_config();
+            break;
+        /*
+         * When needed migrations can be implemented like this:
+         *
+         * case 1:
+         *   config->new_field = some_default_value;
+         * case 2:
+         *   config->another_new_field = some_default_value;
+         * case 3:
+         *   config->another_new_field = some_default_value;
+         *   break;
+         *
+         * Note that the `break` statement should only be used on the last migration step, all the previous steps must fall
+         * through to the next case.
+         */
+        default:
+            NRF_LOG_ERROR("Unsupported configuration migration attempted! (%d -> %d)", config.version, SETTINGS_CURRENT_VERSION);
+            break;
+    }
+}
+
 void settings_load_config(void)
 {
     bool ret = fds_read_sync(FDS_SETTINGS_ID, FDS_SETTINGS_KEY, sizeof(config), (uint8_t *)&config);
     if (ret) {
-        // After the reading is complete, we first save a copy of the current CRC, which can be used as a reference for comparison of changes when saving later
-        calc_14a_crc_lut((uint8_t *)&config, sizeof(config), (uint8_t *)&m_config_crc);
         NRF_LOG_INFO("Load config done.");
+        // After the reading is complete, we first save a copy of the current CRC, which can be used as a reference for comparison of changes when saving later
+        update_config_crc();
     } else {
-        NRF_LOG_INFO("config no exists.");
+        NRF_LOG_WARNING("Config does not exist, loading default values...");
+        settings_init_config();
+    }
+    if (config.version > SETTINGS_CURRENT_VERSION) {
+        NRF_LOG_WARNING("Config version %d is greater than current firmware supports (%d). Default config will be loaded.", config.version, SETTINGS_CURRENT_VERSION);
+        settings_init_config();
+    }
+    if (config.version < SETTINGS_CURRENT_VERSION) {
+        NRF_LOG_INFO("Config version (%d) is not latest, performing migration to %d", config.version, SETTINGS_CURRENT_VERSION);
+        settings_migrate();
+    }
+    if (config_did_change()) {
+        settings_save_config();
     }
 }
 
 uint8_t settings_save_config(void)
 {
     // We are saving the configuration, we need to calculate the crc code of the current configuration to judge whether the following data is updated
-    uint16_t new_calc_crc;
-    calc_14a_crc_lut((uint8_t *)&config, sizeof(config), (uint8_t *)&new_calc_crc);
-    if (new_calc_crc != m_config_crc) {    // Before saving, make sure that the configuration has changed
+    if (config_did_change()) {    // Before saving, make sure that the configuration has changed
         NRF_LOG_INFO("Save config start.");
         bool ret = fds_write_sync(FDS_SETTINGS_ID, FDS_SETTINGS_KEY, sizeof(config) / 4, (uint8_t *)&config);
         if (ret) {
             NRF_LOG_INFO("Save config success.");
-            m_config_crc = new_calc_crc; // store new CRC so we know that we've updated the configuration
+            update_config_crc();
         }
         else
         {
@@ -45,7 +100,7 @@ uint8_t settings_save_config(void)
             return STATUS_FLASH_WRITE_FAIL;
         }
     } else {
-        NRF_LOG_INFO("Config no change.");
+        NRF_LOG_INFO("Config did not change.");
     }
 
     return STATUS_DEVICE_SUCCESS;

--- a/firmware/application/src/settings.h
+++ b/firmware/application/src/settings.h
@@ -3,15 +3,17 @@
 
 #include <stdint.h>
 
+#include "utils.h"
+
 #define SETTINGS_ANIMATION_FULL 0
 #define SETTINGS_ANIMATION_MINIMAL 1
 #define SETTINGS_ANIMATION_NONE 2
 
-/*
- * bits [0-1]: animation config
- * bits [2-31]: reserved
- */
-typedef uint32_t settings_data_t;
+
+typedef struct ALIGN_U32 {
+    uint16_t version;
+    uint16_t animation_config : 2;
+} settings_data_t;
 
 void settings_load_config(void);
 uint8_t settings_save_config(void);

--- a/firmware/application/src/settings.h
+++ b/firmware/application/src/settings.h
@@ -1,0 +1,21 @@
+#ifndef SETTINGS_H
+#define SETTINGS_H
+
+#include <stdint.h>
+
+#define SETTINGS_ANIMATION_FULL 0
+#define SETTINGS_ANIMATION_MINIMAL 1
+#define SETTINGS_ANIMATION_NONE 2
+
+/*
+ * bits [0-1]: animation config
+ * bits [2-31]: reserved
+ */
+typedef uint32_t settings_data_t;
+
+void settings_load_config(void);
+uint8_t settings_save_config(void);
+uint8_t settings_get_animation_config();
+void settings_set_animation_config(uint8_t value);
+
+#endif

--- a/firmware/application/src/settings.h
+++ b/firmware/application/src/settings.h
@@ -5,19 +5,27 @@
 
 #include "utils.h"
 
-#define SETTINGS_ANIMATION_FULL 0
-#define SETTINGS_ANIMATION_MINIMAL 1
-#define SETTINGS_ANIMATION_NONE 2
+#define SETTINGS_CURRENT_VERSION 1
 
+typedef enum {
+    SettingsAnimationModeFull = 0,
+    SettingsAnimationModeMinimal = 1,
+    SettingsAnimationModeNone = 2,
+} settings_animation_mode_t;
 
 typedef struct ALIGN_U32 {
     uint16_t version;
-    uint16_t animation_config : 2;
+    uint8_t animation_config : 2;
+    uint16_t reserved0 : 14;
+    uint32_t reserved1;
+    uint32_t reserved2;
 } settings_data_t;
 
+void settings_init_config(void);
+void settings_migrate(void);
 void settings_load_config(void);
 uint8_t settings_save_config(void);
-uint8_t settings_get_animation_config();
+uint8_t settings_get_animation_config(void);
 void settings_set_animation_config(uint8_t value);
 
 #endif

--- a/firmware/application/src/utils/fds_ids.h
+++ b/firmware/application/src/utils/fds_ids.h
@@ -1,0 +1,30 @@
+#ifndef FDS_IDS_H
+#define FDS_IDS_H
+
+/*
+ * 卡槽配置，只有一份，一致即可
+ */
+#define FDS_CONFIG_RECORD_FILE_KEY   0x1066
+#define FDS_CONFIG_RECORD_FILE_ID    0x1066
+
+/*
+ * 每个卡槽有高低频两种数据，其中key是跟卡槽走的，而id+n就等于数据索引，固定某个索引为指定类型即可
+ * 每个slot的file_key都不一样
+ * 每个slot有两种类型的卡片，因此有两个数据ID（当前）
+ */
+#define FDS_SLOT_TAG_DUMP_FILE_KEY   0x1067
+#define FDS_SLOT_TAG_DUMP_FILE_ID    0x1067
+
+/*
+ * 每个卡槽有高低频两种数据，因此卡槽的昵称也要有两种，其中key是跟卡槽走的，而id+n就等于数据索引，固定某个索引为指定类型即可
+ */
+#define FDS_SLOT_TAG_NICK_NAME_KEY   0x1068
+#define FDS_SLOT_TAG_NICK_NAME_ID    0x1068
+
+/*
+ * Slot for settings like LED animation mode and future options
+ */
+#define FDS_SETTINGS_KEY        0x1069
+#define FDS_SETTINGS_ID         0x1069
+
+#endif

--- a/firmware/common/utils.h
+++ b/firmware/common/utils.h
@@ -1,0 +1,7 @@
+#ifndef UTILS_H_
+#define UTILS_H_
+
+// u32 size align.
+#define ALIGN_U32  __attribute__((aligned(4)))
+
+#endif

--- a/software/script/chameleon_cli_main.py
+++ b/software/script/chameleon_cli_main.py
@@ -87,6 +87,15 @@ class ChameleonCLI:
                     'help': "Emulation tag slot.",
                 },
                 'dfu': new_uint(chameleon_cli_unit.HWDFU, "Restart application to bootloader mode(Not yet implement dfu)."),
+                'settings': {
+                    'animation': {
+                        'get': new_uint(chameleon_cli_unit.HWSettingsAnimationGet, "Get current animation mode value"),
+                        'set': new_uint(chameleon_cli_unit.HWSettingsAnimationSet, "Change chameleon animation mode"),
+                        'help': 'Manage wake-up and sleep animation mode'
+                    },
+                    'store': new_uint(chameleon_cli_unit.HWSettingsStore, "Store current settings to flash"),
+                    'help': "Chameleon settings management"
+                },
                 'help': "hardware controller",
             },
             'hf': {

--- a/software/script/chameleon_cli_main.py
+++ b/software/script/chameleon_cli_main.py
@@ -94,6 +94,7 @@ class ChameleonCLI:
                         'help': 'Manage wake-up and sleep animation mode'
                     },
                     'store': new_uint(chameleon_cli_unit.HWSettingsStore, "Store current settings to flash"),
+                    'reset': new_uint(chameleon_cli_unit.HWSettingsReset, "Reset settings to default values"),
                     'help': "Chameleon settings management"
                 },
                 'help': "hardware controller",

--- a/software/script/chameleon_cli_main.py
+++ b/software/script/chameleon_cli_main.py
@@ -152,14 +152,15 @@ class ChameleonCLI:
         cmds = cmd_str.split(" ")
         cmd_maps: dict or types.FunctionType = self.cmd_maps
         cmd_end = ""
+        cmd_end_position = 0
         for cmd in cmds:
             if cmd in cmd_maps:  # CMD found in map, we can continue find next
                 cmd_maps = cmd_maps[cmd]
                 cmd_end = cmd
+                cmd_end_position += len(cmd) + 1
             else:  # CMD not found
                 break
-        cmd_end_position = cmd_str.index(cmd_end) + len(cmd_end) + 1
-        return cmd_maps, (cmd_str[:cmd_end_position], cmd_str[cmd_end_position:])
+        return cmd_maps, (cmd_str[:cmd_end_position - 1], cmd_str[cmd_end_position:])
 
     def startCLI(self):
         """

--- a/software/script/chameleon_cli_unit.py
+++ b/software/script/chameleon_cli_unit.py
@@ -1032,3 +1032,15 @@ class HWSettingsStore(DeviceRequiredUnit):
             print(" - Store success @.@~")
         else:
             print(" - Store failed")
+
+class HWSettingsReset(DeviceRequiredUnit):
+    def args_parser(self) -> ArgumentParserNoExit or None:
+        return None
+
+    def on_exec(self, args: argparse.Namespace):
+        print("Initializing settings...")
+        resp: chameleon_com.Response = self.cmd_standard.reset_settings()
+        if resp.status == chameleon_status.Device.STATUS_DEVICE_SUCCESS:
+            print(" - Reset success @.@~")
+        else:
+            print(" - Reset failed")

--- a/software/script/chameleon_cli_unit.py
+++ b/software/script/chameleon_cli_unit.py
@@ -1013,7 +1013,7 @@ class HWSettingsAnimationSet(DeviceRequiredUnit):
     def args_parser(self) -> ArgumentParserNoExit or None:
         parser = ArgumentParserNoExit()
         parser.add_argument('-m', '--mode', type=int, required=True, help="0 is full (default), 1 is minimal (only single pass on button wakeup), 2 is none", choices=[0, 1, 2])
-        return None
+        return parser
     
     def on_exec(self, args: argparse.Namespace):
         mode = args.mode

--- a/software/script/chameleon_cli_unit.py
+++ b/software/script/chameleon_cli_unit.py
@@ -994,3 +994,41 @@ class HWDFU(DeviceRequiredUnit):
         print(" - Enter success @.@~")
         # let time for comm thread to send dfu cmd and close port
         time.sleep(0.1)
+
+class HWSettingsAnimationGet(DeviceRequiredUnit):
+    def args_parser(self) -> ArgumentParserNoExit or None:
+        return None
+    def on_exec(self, args: argparse.Namespace):
+        resp: chameleon_com.Response = self.cmd_standard.get_settings_animation()
+        if resp.data[0] == 0:
+            print("Full animation")
+        elif resp.data[0] == 1:
+            print("Minimal animation")
+        elif resp.data[0] == 2:
+            print("No animation")
+        else:
+            print("Unknown setting value, something failed.")
+
+class HWSettingsAnimationSet(DeviceRequiredUnit):
+    def args_parser(self) -> ArgumentParserNoExit or None:
+        parser = ArgumentParserNoExit()
+        parser.add_argument('-m', '--mode', type=int, required=True, help="0 is full (default), 1 is minimal (only single pass on button wakeup), 2 is none", choices=[0, 1, 2])
+        return None
+    
+    def on_exec(self, args: argparse.Namespace):
+        mode = args.mode
+        self.cmd_standard.set_settings_animation(mode)
+        print("Animation mode change success. Do not forget to store your settings in flash!")
+    
+
+class HWSettingsStore(DeviceRequiredUnit):
+    def args_parser(self) -> ArgumentParserNoExit or None:
+        return None
+    
+    def on_exec(self, args: argparse.Namespace):
+        print("Storing settings...")
+        resp: chameleon_com.Response = self.cmd_standard.store_settings()
+        if resp.status == chameleon_status.Device.STATUS_DEVICE_SUCCESS:
+            print(" - Store success @.@~")
+        else:
+            print(" - Store failed")

--- a/software/script/chameleon_cmd.py
+++ b/software/script/chameleon_cmd.py
@@ -21,8 +21,9 @@ DATA_CMD_GET_DEVICE_CHIP_ID = 1011
 DATA_CMD_GET_DEVICE_ADDRESS = 1012
 
 DATA_CMD_SAVE_SETTINGS = 1013
-DATA_CMD_SET_ANIMATION_MODE = 1014
-DATA_CMD_GET_ANIMATION_MODE = 1015
+DATA_CMD_RESET_SETTINGS = 1014
+DATA_CMD_SET_ANIMATION_MODE = 1015
+DATA_CMD_GET_ANIMATION_MODE = 1016
 
 DATA_CMD_SCAN_14A_TAG = 2000
 DATA_CMD_MF1_SUPPORT_DETECT = 2001
@@ -441,6 +442,12 @@ class BaseChameleonCMD:
         """
         return self.device.send_cmd_sync(DATA_CMD_SET_ANIMATION_MODE, 0x00, bytearray([value]))
     
+    def reset_settings(self):
+        """
+        Reset settings stored in flash memory
+        """
+        return self.device.send_cmd_sync(DATA_CMD_RESET_SETTINGS, 0x00)
+
     def store_settings(self):
         """
         Store settings to flash memory

--- a/software/script/chameleon_cmd.py
+++ b/software/script/chameleon_cmd.py
@@ -20,6 +20,10 @@ DATA_CMD_ENTER_BOOTLOADER = 1010
 DATA_CMD_GET_DEVICE_CHIP_ID = 1011
 DATA_CMD_GET_DEVICE_ADDRESS = 1012
 
+DATA_CMD_SAVE_SETTINGS = 1013
+DATA_CMD_SET_ANIMATION_MODE = 1014
+DATA_CMD_GET_ANIMATION_MODE = 1015
+
 DATA_CMD_SCAN_14A_TAG = 2000
 DATA_CMD_MF1_SUPPORT_DETECT = 2001
 DATA_CMD_MF1_NT_LEVEL_DETECT = 2002
@@ -424,6 +428,24 @@ class BaseChameleonCMD:
         :return:
         """
         return self.device.send_cmd_auto(DATA_CMD_ENTER_BOOTLOADER, 0x00, close=True)
+    
+    def get_settings_animation(self):
+        """
+        Get animation mode value
+        """
+        return self.device.send_cmd_sync(DATA_CMD_GET_ANIMATION_MODE, 0x00, None)
+    
+    def set_settings_animation(self, value: int):
+        """
+        Set animation mode value
+        """
+        return self.device.send_cmd_sync(DATA_CMD_SET_ANIMATION_MODE, 0x00, bytearray([value]))
+    
+    def store_settings(self):
+        """
+        Store settings to flash memory
+        """
+        return self.device.send_cmd_sync(DATA_CMD_SAVE_SETTINGS, 0x00)
 
 
 class NegativeResponseError(Exception):

--- a/software/script/chameleon_status.py
+++ b/software/script/chameleon_status.py
@@ -41,6 +41,8 @@ class Device(metaclass=MetaDevice):
     STATUS_INVALID_CMD                      = 0x67  # 无效的指令
     STATUS_DEVICE_SUCCESS                   = 0x68  # 设备相关操作成功执行
     STATUS_NOT_IMPLEMENTED                  = 0x69  # 调用了某些未实现的操作，属于开发者遗漏的错误
+    STATUS_FLASH_WRITE_FAIL                 = 0x70  # flash写入失败
+    STATUS_FLASH_READ_FAIL                  = 0x71  # flash读取失败
 
 
 message = {
@@ -68,4 +70,6 @@ message = {
     Device.STATUS_INVALID_CMD               : "API request fail, cmd invalid",
     Device.STATUS_DEVICE_SUCCESS            : "Device operation succeeded",
     Device.STATUS_NOT_IMPLEMENTED           : "Some api not implemented",
+    Device.STATUS_FLASH_WRITE_FAIL          : "Flash write failed",
+    Device.STATUS_FLASH_READ_FAIL           : "Flash read failed"
 }


### PR DESCRIPTION
This change adds animation change support + ability to control it from CLI.
By default it uses full animation mode (as stock firmware) but it allows user to disable wake-up and sleep animations completely (mode 2) or use minimal animation (mode 1).

The reason for making this change is that waiting even for this single cycle of led swipe when triggered by reader makes it hard to use with some readers. Moreover, having such long animations is, to say the least, frustrating. 

Reason of having mode 1 is that when there is no animation at all when you wake Chameleon with button press, button up is registered as command to change slot, so slight delay helps alleviate that problem. In this mode there is no sleep swipe nor rf field wake-up animation. 

In both mode 1 and 2 there are animations for USB, slot change etc, I didn't change those as they didn't impact user experience.

This PR also adds 32 bit field to store user settings in flash - led animation uses 2 of them, next setting proposed on Discord is disabling bluetooth, which could also use one bit of this settings field.