### PR TITLE
Fix data sanity check

### DIFF
--- a/firmware/application/src/app_cmd.c
+++ b/firmware/application/src/app_cmd.c
@@ -407,13 +407,13 @@ data_frame_tx_t* cmd_processor_get_mf1_detection_log(uint16_t cmd, uint16_t stat
 data_frame_tx_t* cmd_processor_set_mf1_emulator_block(uint16_t cmd, uint16_t status, uint16_t length, uint8_t *data) {
     if (length > 0 && (((length - 1) % NFC_TAG_MF1_DATA_SIZE) == 0)) {
         uint8_t block_index = data[0];
-        uint8_t block_count = (length - 1) % NFC_TAG_MF1_DATA_SIZE;
+        uint8_t block_count = (length - 1) / NFC_TAG_MF1_DATA_SIZE;
         if (block_index + block_count > NFC_TAG_MF1_BLOCK_MAX) {
             status = STATUS_PAR_ERR;
         } else {
             tag_data_buffer_t* buffer = get_buffer_by_tag_type(TAG_TYPE_MIFARE_4096);
             nfc_tag_mf1_information_t *info = (nfc_tag_mf1_information_t *)buffer->buffer;
-            for (int i = 1, j = block_index; i < length - 1; i += NFC_TAG_MF1_DATA_SIZE, j++) {
+            for (int i = 1, j = block_index; i < length; i += NFC_TAG_MF1_DATA_SIZE, j++) {
                 uint8_t *p_block = &data[i];
                 memcpy(info->memory[j], p_block, NFC_TAG_MF1_DATA_SIZE);
             }


### PR DESCRIPTION
Fixed block_count calculation in cmd_processor_set_mf1_emulator_block.

Changed loop boundary to length. Although it does not affect behavior, it is confusing to have length - 1 as a boundary because we want to parse data elements from 1 to length - 1 including.