### PR TITLE
Fix stuff I broke yesterday

### DIFF
--- a/firmware/build.sh
+++ b/firmware/build.sh
@@ -60,15 +60,19 @@ set -xe
     --merge \
     settings.hex \
     application.hex \
-    --output application.hex
-  rm settings.hex
+    --output application_merged.hex
 
   mergehex \
     --merge \
       bootloader.hex \
-      application.hex \
+      application_merged.hex \
       softdevice.hex \
     --output fullimage.hex
 
-  zip ${device_type}-binaries.zip *.hex
+  tmp_dir=$(mktemp -d -t cu_binaries_XXXXXXXXXX)
+  cp *.hex "$tmp_dir"
+  mv $tmp_dir/application_merged.hex $tmp_dir/application.hex
+  rm $tmp_dir/settings.hex
+  zip -j ${device_type}-binaries.zip $tmp_dir/*.hex
+  rm -rf $tmp_dir
 )

--- a/firmware/flash-dfu-app.sh
+++ b/firmware/flash-dfu-app.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+if [[ $BASH_SOURCE = */* ]]; then
+  cd -- "${BASH_SOURCE%/*}/" || exit
+fi
+
 if ! ../resource/tools/enter_dfu.py; then
     echo "Wait for device to be off"
     echo "Press B and plug"
@@ -9,4 +13,19 @@ while :; do
   lsusb|grep -q 1915:521f && break
   sleep 1
 done
-nrfutil device program --firmware objects/dfu-app.zip --traits nordicDfu
+
+device_type=ultra
+lsusb | grep 1915:521f | grep -q ChameleonLite && device_type=lite
+
+echo "Flashing $device_type"
+
+dfu_package=objects/${device_type}-dfu-app.zip
+
+if [ ! -f $dfu_package ]; then
+    echo "DFU package for $device_type not found, aborting."
+    echo "Build firmware using CURRENT_DEVICE_TYPE=$device_type firmware/build.sh"
+    exit 1
+fi
+
+nrfutil device program --firmware $dfu_package --traits nordicDfu
+

--- a/firmware/flash-dfu-full.sh
+++ b/firmware/flash-dfu-full.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+if [[ $BASH_SOURCE = */* ]]; then
+  cd -- "${BASH_SOURCE%/*}/" || exit
+fi
+
 if ! ../resource/tools/enter_dfu.py; then
     echo "Wait for device to be off"
     echo "Press B and plug"
@@ -9,4 +13,19 @@ while :; do
   lsusb|grep -q 1915:521f && break
   sleep 1
 done
-nrfutil device program --firmware objects/dfu-full.zip --traits nordicDfu
+
+device_type=ultra
+lsusb | grep 1915:521f | grep -q ChameleonLite && device_type=lite
+
+echo "Flashing $device_type"
+
+dfu_package=objects/${device_type}-dfu-full.zip
+
+if [ ! -f $dfu_package ]; then
+    echo "DFU package for $device_type not found, aborting."
+    echo "Build firmware using CURRENT_DEVICE_TYPE=$device_type firmware/build.sh"
+    exit 1
+fi
+
+nrfutil device program --firmware $dfu_package --traits nordicDfu
+


### PR DESCRIPTION
Fixes `Overlapping segments detected at address 1040384.ERROR: The hex files cannot be merged since there are conflicts.`
Was caused by `build.sh` overwriting `application.hex` with a version merged with bootloader settings, wasn't catched during testing because only clean builds were tested.
Fix involves using a temp directory for storing the binaries that will be put into `type-binaries.zip` so that the merged application can be renamed to `application.hex` without breaking successive builds.

`flash-dfu-*.sh` scripts have also been fixed to account for the new file names and to properly enter dfu even if script is ran from repo root (for example `firmware/flash-dfu-app.sh`)