### PR TITLE
Fix multiple Chameleon connected on WSL1

### DIFF
--- a/software/script/chameleon_cli_unit.py
+++ b/software/script/chameleon_cli_unit.py
@@ -200,7 +200,7 @@ class HWConnect(BaseCLIUnit):
                             break
                     if PSHEXE:
                         #process = subprocess.Popen([PSHEXE,"Get-CimInstance -ClassName Win32_serialport | Where-Object {$_.PNPDeviceID -like '*VID_6868&PID_8686*'} | Select -expandproperty DeviceID"],stdout=subprocess.PIPE);
-                        process = subprocess.Popen([PSHEXE,"Get-PnPDevice -Class Ports -PresentOnly | where {$_.DeviceID -like '*VID_6868&PID_8686*'} | Select-Object FriendlyName | % FriendlyName | select-string COM\d+ |% { $_.matches.value }"],stdout=subprocess.PIPE);
+                        process = subprocess.Popen([PSHEXE,"Get-PnPDevice -Class Ports -PresentOnly | where {$_.DeviceID -like '*VID_6868&PID_8686*'} | Select-Object -First 1 FriendlyName | % FriendlyName | select-string COM\d+ |% { $_.matches.value }"],stdout=subprocess.PIPE);
                         res = process.communicate()[0]
                         _comport = res.decode('utf-8').strip()
                         if _comport:


### PR DESCRIPTION
Avoid

```
Chameleon Connect fail: [Errno 2] could not open port /dev/ttyS15
/dev/ttyS39: [Errno 2] No such file or directory: '/dev/ttyS15\r\n/dev/ttyS39'
```

By only returning the first COM port with `VID_6868&PID_8686`