### PR TITLE
Fix device address is not the same with APP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project uses the changelog in accordance with [keepchangelog](http://keepachangelog.com/). Please use this to write notable changes, which is not the same as git commit log...
 
 ## [unreleased][unreleased]
+ - Fix device address is not the same with APP (@taichunmin)
  - Added initial version of the user guides (@GameTec-live)
  - Added support for pasting several command lines at once with prompt_toolkit (@doegox)
  - Added support for interrupting sleep sequence with a button press during animation (@doegox)

--- a/firmware/application/src/app_cmd.c
+++ b/firmware/application/src/app_cmd.c
@@ -83,8 +83,12 @@ data_frame_tx_t *cmd_processor_get_device_chip_id(uint16_t cmd, uint16_t status,
 
 data_frame_tx_t *cmd_processor_get_device_address(uint16_t cmd, uint16_t status, uint16_t length, uint8_t *data) {
     uint32_t device_address[2];
+    // The FICR value is a just a random number, with no knowledge
+    // of the Bluetooth Specification requirements for random addresses.
+    // So we need to set a Bluetooth LE random address as a static address.
+    // See: https://github.com/zephyrproject-rtos/zephyr/blob/7b6b1328a0cb96fe313a5e2bfc57047471df236e/subsys/bluetooth/controller/hci/nordic/hci_vendor.c#L29
     device_address[0] = NRF_FICR->DEVICEADDR[0];
-    device_address[1] = NRF_FICR->DEVICEADDR[1];
+    device_address[1] = NRF_FICR->DEVICEADDR[1] | 0xC000;
     return data_frame_make(cmd, STATUS_DEVICE_SUCCESS, 6, (uint8_t *)(&device_address[0]));
 }
 


### PR DESCRIPTION
When I use the `DATA_CMD_GET_DEVICE_ADDRESS` cmd, I find the response is different with the address displayed from Android CU GUI.

So I found the `FICR->DEVICEADDR` is random addr, need to convert to static addr.