### PR TITLE
Fix argument autocompleter bug (#97)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project uses the changelog in accordance with [keepchangelog](http://keepachangelog.com/). Please use this to write notable changes, which is not the same as git commit log...
 
 ## [unreleased][unreleased]
+ - Fixed argument completion bug inserting additional hyphens (@szymex73)
  - Added initial version of the user guides (@GameTec-live)
  - Added support for pasting several command lines at once with prompt_toolkit (@doegox)
  - Added support for interrupting sleep sequence with a button press during animation (@doegox)

--- a/software/script/chameleon_utils.py
+++ b/software/script/chameleon_utils.py
@@ -265,7 +265,7 @@ class ArgparseCompleter(Completer):
 
     def get_completions(self, document, complete_event):
         text = document.text_before_cursor
-        word_before_cursor = document.get_word_before_cursor()
+        word_before_cursor = document.text_before_cursor.split(' ')[-1]
 
         _, _, suggestions = self.check_tokens(list(), text.split())
 


### PR DESCRIPTION
This fixes the autocomplete bug that would insert additional hyphens after tab-completing arguments.

Closes #97