### PR TITLE
Fix a bug in multiline command implementation

### DIFF
--- a/software/script/chameleon_cli_main.py
+++ b/software/script/chameleon_cli_main.py
@@ -106,13 +106,13 @@ class ChameleonCLI:
                 try:
                     cmd_str = self.session.prompt(
                         ANSI(self.get_prompt())).strip()
+                    cmd_strs = cmd_str.replace(
+                        "\r\n", "\n").replace("\r", "\n").split("\n")
+                    cmd_str = cmd_strs.pop(0)
                 except EOFError:
                     closing = True
                 except KeyboardInterrupt:
                     closing = True
-                cmd_strs = cmd_str.replace(
-                    "\r\n", "\n").replace("\r", "\n").split("\n")
-                cmd_str = cmd_strs.pop(0)
 
             if closing or cmd_str in ["exit", "quit", "q", "e"]:
                 print("Bye, thank you.  ^.^ ")


### PR DESCRIPTION
This fixes a bug where after a KeyboardInterrupt the application would crash since it would try to split a string that does not exist.