### PR TITLE
Change Chameleon Lite PID to 0x8787

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project uses the changelog in accordance with [keepchangelog](http://keepachangelog.com/). Please use this to write notable changes, which is not the same as git commit log...
 
 ## [unreleased][unreleased]
+ - Changed Chameleon Lite PID to `0x8787` (@Foxushka)
  - Security BLE implemented (@xianglin1998)
  - Added `hw settings blekey` to get and set ble connect key (@xianglin1998)
  - Added `hw ble bonds clear` to delete all ble bonds (@xianglin1998)

--- a/firmware/application/src/sdk_config.h
+++ b/firmware/application/src/sdk_config.h
@@ -6420,7 +6420,7 @@
 // <i> Selected Product ID
 
 #ifndef APP_USBD_PID
-#define APP_USBD_PID 0x8686
+#define APP_USBD_PID DEVICE_PID
 #endif
 
 // <o> APP_USBD_DEVICE_VER_MAJOR - Major device version  <0-99>

--- a/firmware/common/device_info.h
+++ b/firmware/common/device_info.h
@@ -5,9 +5,11 @@
 #if defined(PROJECT_CHAMELEON_ULTRA)
 #define DEVICE_NAME_STR         "ChameleonUltra"
 #define DEVICE_NAME_STR_SHORT   "CU"
+#define DEVICE_PID              0x8686
 #elif defined(PROJECT_CHAMELEON_LITE)
 #define DEVICE_NAME_STR         "ChameleonLite"
 #define DEVICE_NAME_STR_SHORT   "CL"
+#define DEVICE_PID              0x8787
 #else
 #error "Unknown device name?"
 #endif

--- a/resource/driver/79-chameleon-usb-device-blacklist-dialout.rules
+++ b/resource/driver/79-chameleon-usb-device-blacklist-dialout.rules
@@ -11,6 +11,8 @@ ACTION!="add|change", GOTO="chameleon_usb_device_blacklist_end"
 SUBSYSTEM!="tty", GOTO="chameleon_ignore"
 
 ATTRS{idVendor}=="6868" ATTRS{idProduct}=="8686", ENV{ID_MM_DEVICE_IGNORE}="1" SYMLINK+="ultra-%n" MODE="660" GROUP="dialout"
+ATTRS{idVendor}=="6868" ATTRS{idProduct}=="8787", ENV{ID_MM_DEVICE_IGNORE}="1" SYMLINK+="lite-%n" MODE="660" GROUP="dialout"
+
 
 LABEL="chameleon_ignore"
 ATTRS{idVendor}=="2d2d" ATTRS{idProduct}=="504d", ENV{ID_MM_DEVICE_IGNORE}="1"

--- a/resource/tools/enter_dfu.py
+++ b/resource/tools/enter_dfu.py
@@ -10,7 +10,7 @@ for comport in list_ports.comports():
     if comport.vid == 0x1915 and comport.pid == 0x521f:
         print("Chameleon already in DFU mode")
         exit(0)
-    if comport.vid == 0x6868 and comport.pid == 0x8686:
+    if comport.vid == 0x6868 and (comport.pid == 0x8686 or comport.pid == 0x8787):
         port = comport.device
         break
 

--- a/software/script/chameleon_cli_unit.py
+++ b/software/script/chameleon_cli_unit.py
@@ -210,10 +210,10 @@ class HWConnect(BaseCLIUnit):
                             break
                     if PSHEXE:
                         # process = subprocess.Popen([PSHEXE,"Get-CimInstance -ClassName Win32_serialport |"
-                        # " Where-Object {$_.PNPDeviceID -like '*VID_6868&PID_8686*'} |"
+                        # " Where-Object {$_.PNPDeviceID -like '*VID_6868&PID_*'} |"
                         # " Select -expandproperty DeviceID"],stdout=subprocess.PIPE);
                         process = subprocess.Popen([PSHEXE, "Get-PnPDevice -Class Ports -PresentOnly |"
-                                                    " where {$_.DeviceID -like '*VID_6868&PID_8686*'} |"
+                                                    " where {$_.DeviceID -like '*VID_6868&PID_*'} |"
                                                     " Select-Object -First 1 FriendlyName |"
                                                     " % FriendlyName |"
                                                     " select-string COM\d+ |"


### PR DESCRIPTION
This will give us ability to separate ultra/lite without ugly hacks like `if "ChameleonUltra" in productName` (and as productName not even available in Web Serial API)
udev rule updated too, lite should appear in /dev/lite-X