### PR TITLE
Add public roadmap and wishlist documentation

### DIFF
--- a/docs/wiki/public-roadmap.md
+++ b/docs/wiki/public-roadmap.md
@@ -1,0 +1,51 @@
+Public Roadmap for ChameleonUltra Project
+=========================================
+
+Pages
+-----
+
+* * *
+
+Introduction
+------------
+
+There's a need for a roadmap where contributors can easily understand the project's vision and the functionalities that require attention. If you have an idea for a feature, please refer to the wishlist.
+
+* * *
+
+Great Stuff (Future Developments)
+---------------------------------
+
+### In Progress
+
+*   **Firmware Updates & Compatibility**: Addressing issues related to firmware updates and compatibility.
+*   **New Protocols & Mifare 1k Card Simulation**: Working on adding new protocols, including Mifare 1k card simulation.
+
+### To-Do
+
+*   **Hardware Revisions**: Planning future hardware revisions for performance enhancement.
+*   **Software Tools**: Development of new software tools is on the horizon.
+*   **Community Contributions & Development**: Encouraging and integrating community contributions.
+*   **Mfc 1k Full Emulation**: Implementing full emulation for Mfc 1k cards.
+*   **BLE Connection Feedback**: Enhancing BLE connection documentation.
+*   **mfkey32 Issues**: Resolving nonce collection issues in mfkey32.
+*   **Enhanced UID Copying**: Implementing offline UID copying via A/B button.
+*   **CMD 1002 Timeout**: Addressing device timeouts related to CMD 1002.
+*   **Device Connection Failures**: Resolving device connection issues.
+*   **Insecure BLE Connection**: Addressing BLE security vulnerabilities.
+
+* * *
+
+Accomplished Stuff
+------------------
+
+*   _This section will be updated as tasks are completed._
+
+* * *
+
+Impossible Ideas
+----------------
+
+*   _This section can include ideas that are currently unfeasible due to hardware or other limitations._
+
+* * *

--- a/docs/wiki/wishlist.md
+++ b/docs/wiki/wishlist.md
@@ -1,0 +1,52 @@
+* * *
+
+Wishlist for ChameleonUltra Project
+===================================
+
+Introduction
+------------
+
+This page serves as a collection of features, improvements, and ideas that the community would like to see implemented in the ChameleonUltra project. While these are not currently in development, they offer a vision for future possibilities.
+
+* * *
+
+Desired Features
+----------------
+
+### Security
+
+
+### Usability
+
+*   **Mobile App Support**: A dedicated mobile app for easier configuration and monitoring.
+
+### Performance
+
+*   **Faster Data Transfer**: Implement faster protocols for quicker data transfer between devices.
+
+### Protocols & Standards
+
+*   **Support for Additional RFID Standards**: Such as ISO 18000-6C, ISO 14443B, etc.
+*   **NFC Payment Simulation**: Simulate NFC payment cards for testing purposes.
+
+### Hardware
+
+*   **Smaller Form Factor**: A more compact version of the device.
+*   **Built-in Display**: A small screen to display real-time information.
+
+### Miscellaneous
+
+*   **Open Source Hardware Design**: Release the hardware design files to the public.
+
+* * *
+
+Moonshot Ideas
+--------------
+
+*   **AI-Powered Analysis**: Use machine learning to identify patterns or anomalies in RFID usage.
+
+* * *
+
+Feel free to contribute your ideas to this wishlist. Your input is valuable in shaping the future of the ChameleonUltra project.
+
+* * *


### PR DESCRIPTION
This commit adds the public roadmap and wishlist documentation to the project's wiki. The public roadmap provides an overview of the project's vision and ongoing developments, including firmware updates, new protocols, hardware revisions, software tools, community contributions, and more. The wishlist serves as a collection of desired features and moonshot ideas for future development. For now the things written in the wishlist are kind of placeholders. Ideally this contents should go to the Wiki