### PR TITLE
Mfc 1k Full emulation (not UID only) with OEM readers bugs fixed.

### DIFF
--- a/firmware/application/src/rfid/nfctag/hf/nfc_mf1.h
+++ b/firmware/application/src/rfid/nfctag/hf/nfc_mf1.h
@@ -5,7 +5,7 @@
 
 // Exchange space for time.
 // Fast simulate enable(Implement By ChameleonMini Repo)
-#define NFC_MF1_FAST_SIM
+// #define NFC_MF1_FAST_SIM
 
 #define NFC_TAG_MF1_DATA_SIZE   16
 #define NFC_TAG_MF1_FRAME_SIZE  (NFC_TAG_MF1_DATA_SIZE + NFC_TAG_14A_CRC_LENGTH)


### PR DESCRIPTION
After nearly a week of testing and attempted repairs, MFC simulation is now compatible with most OEM readers and has solved the compatibility issues with mobile phones caused by fixing OEM compatibility issues. Note that this change temporarily disable FAST_SIM, this may not be the final fix we want. In theory, we should focus on FAST_SIM functionality is controllable, rather than simply disable.

The fixed of this big bug cannot do without the help of the community. Thanks to @doegox and @spp2000, as well as to many others in the community for their help.

Based on feedback from the current community, this fix can make their OEM card readers work perfectly. If you encounter issues that cannot work on OEM card readers, please try update to this firmware. And after the test, please feedback your result to this PR's comment section. Thank you very much.