### PR TITLE
Proper 14443-4a support

### DIFF
--- a/firmware/application/src/app_main.c
+++ b/firmware/application/src/app_main.c
@@ -648,11 +648,16 @@ static void btn_fn_copy_ic_uid(void) {
     status = pcd_14a_reader_scan_auto(&tag);
     if (status == HF_TAG_OK) {
         // copy uid
+        antres->size = tag.uid_len;
         memcpy(antres->uid, tag.uid, tag.uid_len);
         // copy atqa
         memcpy(antres->atqa, tag.atqa, 2);
         // copy sak
         antres->sak[0] = tag.sak;
+        // copy ats
+        antres->ats.length = tag.ats_len;
+        memcpy(antres->ats.data, tag.ats, tag.ats_len);
+
         NRF_LOG_INFO("Offline HF uid copied")
         offline_status_ok();
     } else {

--- a/firmware/application/src/app_status.h
+++ b/firmware/application/src/app_status.h
@@ -13,7 +13,7 @@
 #define     HF_ERR_BCC                              (0x05) // IC card BCC error
 #define     MF_ERR_AUTH                             (0x06) // MF card verification failed
 #define     HF_ERR_PARITY                           (0x07) // IC card parity error
-
+#define     HF_ERR_ATS                              (0x08) // ATS should be present but card NAKed
 
 /////////////////////////////////////////////////////////////////////
 // MIFARE status

--- a/firmware/application/src/rfid/reader/hf/rc522.h
+++ b/firmware/application/src/rfid/reader/hf/rc522.h
@@ -157,6 +157,8 @@ typedef struct {
     uint8_t cascade;  // theAntiCollisionLevelValueIs1Representation 4Byte,2Represents7Byte,3Means10Byte
     uint8_t sak;      // chooseToConfirm
     uint8_t atqa[2];  // requestResponse
+    uint8_t ats[0xFF];// 14443-4 answer to select
+    uint8_t ats_len;  // 14443-4 answer to select size
 } picc_14a_tag_t;
 
 #ifdef __cplusplus

--- a/software/script/chameleon_cli_unit.py
+++ b/software/script/chameleon_cli_unit.py
@@ -856,6 +856,9 @@ class HFMFInfo(DeviceRequiredUnit):
             print(f"- UID  Hex : {info['uid_hex'].upper()}")
             print(f"- SAK  Hex : {info['sak_hex'].upper()}")
             print(f"- ATQA Hex : {info['atqa_hex'].upper()}")
+            if info['ats_size']:
+                print(f"- ATS  Size: {info['ats_size']}")
+                print(f"- ATS  Hex : {info['ats_hex'].upper()}")
             return True
         else:
             print("No data loaded in slot")

--- a/software/script/chameleon_cli_unit.py
+++ b/software/script/chameleon_cli_unit.py
@@ -294,6 +294,9 @@ class HF14AScan(ReaderRequiredUnit):
             print(f"- UID  Hex : {info['uid_hex'].upper()}")
             print(f"- SAK  Hex : {info['sak_hex'].upper()}")
             print(f"- ATQA Hex : {info['atqa_hex'].upper()}")
+            if info['ats_size']:
+                print(f"- ATS  Size: {info['ats_size']}")
+                print(f"- ATS  Hex : {info['ats_hex'].upper()}")
             return True
         else:
             print("ISO14443-A Tag no found")

--- a/software/script/chameleon_cstruct.py
+++ b/software/script/chameleon_cstruct.py
@@ -20,9 +20,11 @@ def parse_14a_scan_tag_result(data: bytearray):
     """
     return {
         'uid_size': data[10],
-        'uid_hex': data[0:data[10]].hex(),
+        'uid_hex': data[0:data[10]].hex(' '),
         'sak_hex': hex(data[12]).lstrip('0x').rjust(2, '0'),
-        'atqa_hex': data[13:15].hex().upper()
+        'atqa_hex': data[13:15].hex(' '),
+        'ats_size': data[270],
+        'ats_hex': data[15:15 + data[270]].hex(' '),
     }
 
 

--- a/software/script/chameleon_status.py
+++ b/software/script/chameleon_status.py
@@ -22,6 +22,7 @@ class Device(metaclass=MetaDevice):
     HF_ERR_BCC = 0x05     # IC card BCC error
     MF_ERR_AUTH = 0x06    # MF card verification failed
     HF_ERR_PARITY = 0x07  # IC card parity error
+    HF_ERR_ATS = 0x08     # ATS should be present but card NAKed
 
     # Darkside, the random number cannot be fixed, this situation may appear on the UID card
     DARKSIDE_CANT_FIXED_NT = 0x20
@@ -63,6 +64,7 @@ message = {
     Device.HF_ERR_BCC: "HF tag uid bcc error",
     Device.MF_ERR_AUTH: "HF tag auth fail",
     Device.HF_ERR_PARITY: "HF tag data parity error",
+    Device.HF_ERR_ATS: "HF tag was supposed to send ATS but didn't",
 
     Device.DARKSIDE_CANT_FIXED_NT: "Darkside Can't select a nt(PRNG is unpredictable)",
     Device.DARKSIDE_LUCK_AUTH_OK: "Darkside try to recover a default key",


### PR DESCRIPTION
Automatically send RATS to 14443-4a tags
Add ATS copy to long press quick clone
Fix long press quick clone supporting only 4b uid