### PR TITLE
Increase initial button wakeup from 4 to 8 seconds

### DIFF
--- a/firmware/application/src/utils/syssleep.h
+++ b/firmware/application/src/utils/syssleep.h
@@ -4,7 +4,7 @@
 #include <stdint.h>
 
 //           Wake up equipment
-#define SLEEP_DELAY_MS_BUTTON_WAKEUP            4000    // The sleep delay of the button awakened
+#define SLEEP_DELAY_MS_BUTTON_WAKEUP            8000    // The sleep delay of the button awakened
 #define SLEEP_DELAY_MS_FIELD_WAKEUP             4000    // The sleep delay (including high and low frequencies) of the field wake -up (including high and low frequency)
 #define SLEEP_DELAY_MS_FIRST_POWER              1000    // The sleep delay of the first power supply (access to the battery)
 


### PR DESCRIPTION
Initial button press wakeup of 4 seconds is sometimes inadequate to establish BT connection. 

This change will expand the Initial button wakeup from 4 seconds to 8 seconds. 

Device sleep behavior after will be as follows:
(Changed)
Initial Button Wakeup to Sleep : 8s 
(No Change)
Subsequent Button Action to Sleep : 4s
Leaving RF Field wake to sleep : 3s
BLE Disconnect to sleep : 4s
USB Power Disconnect to sleep : 3s

Example behavior :
User wakes device with Button B (8 Sec to sleep)
User pushes button B again (Now 4 Sec to sleep) 
User Places device in RF field (Maintain wake)
User removes device from RF field (3 sec to sleep)

If user discontinues the user journey at any point, the identified condition will invoke sleep at defined times.