### PR TITLE
Fix factory reset hang/wdt reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project uses the changelog in accordance with [keepchangelog](http://keepachangelog.com/). Please use this to write notable changes, which is not the same as git commit log...
 
 ## [unreleased][unreleased]
+ - Fixed factory reset hanging (@augustozanellato)
  - Changed fds_write_sync to take length in bytes instead of next multiple of 4 (@doegox)
  - Fixed field LED when LF reading and HF cloning (@doegox)
  - Added renaming of slot into "cloned" when having cloned an ID/UID with a button (@doegox)


### PR DESCRIPTION
fds_util event handler was ignoring all the events related to peer_manager files and that was causing a deadlock while waiting for record deletion that in turn caused a wdt reset, usually this resulted in a partially done factory reset.
The fix adds a `ignore_pm` flag to op_info struct that gets cleared by fds_wipe allowing for a true reset to happen.