### PR TITLE
Corrected wrong text when colorizing argparse help

### DIFF
--- a/software/script/chameleon_utils.py
+++ b/software/script/chameleon_utils.py
@@ -88,8 +88,8 @@ class ArgumentParserNoExit(argparse.ArgumentParser):
                 options = lines
                 lines = []
         if len(options) > 0:
-            assert options[0].strip() == 'options:'
-            options[0] = options[0].replace('options:', f'{CG}options:{C0}')
+            assert options[0].strip() == 'optional arguments:'
+            options[0] = options[0].replace('optional arguments:', f'{CG}optional arguments:{C0}')
             if len(options) > 1:
                 options.append('')
             print('\n'.join(options))


### PR DESCRIPTION
When wrong arguments were used, the CLI would fail for an assert that was expecting a different text.

Changed: "options:" to "optional arguments:"
