### PR TITLE
cli: fix unused target key type parameter for nested

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project uses the changelog in accordance with [keepchangelog](http://keepachangelog.com/). Please use this to write notable changes, which is not the same as git commit log...
 
 ## [unreleased][unreleased]
+ - Fixed unused target key type parameter for nested (@petepriority)
  - Skip already used items `hf mf elog --decrypt` (@p-l-)
  - Parallelize mfkey32v2 processes called from CLI (@p-l-)
  - Added support for mifare classic value block operations (@taichunmin)

--- a/software/script/chameleon_cli_unit.py
+++ b/software/script/chameleon_cli_unit.py
@@ -763,7 +763,7 @@ class HFMFNested(ReaderRequiredUnit):
         key_known_bytes = bytes.fromhex(key_known)
         block_target = args.tblk
         # default to A
-        type_target = MfcKeyType.B if args.b else MfcKeyType.A
+        type_target = MfcKeyType.B if args.tb else MfcKeyType.A
         if block_known == block_target and type_known == type_target:
             print(f"{CR}Target key already known{C0}")
             return


### PR DESCRIPTION
In the nested attack of the cli the target key type parameter (`--ta` / `--tb`) is not used.

This PR sets the `type_target` based on the target key type parameter instead of the known key type parameter.