### PR TITLE
Add CLI view commands to display memory content 

### DIFF
--- a/software/script/chameleon_utils.py
+++ b/software/script/chameleon_utils.py
@@ -102,6 +102,21 @@ class ArgumentParserNoExit(argparse.ArgumentParser):
         print('')
         self.help_requested = True
 
+def print_mem_dump(bindata, blocksize):
+
+    hexadecimal_len = blocksize*3+1
+    ascii_len = blocksize+1
+    print(f"[=] ----+{hexadecimal_len*'-'}+{ascii_len*'-'}")
+    print(f"[=] blk | data{(hexadecimal_len-5)*' '}| ascii")
+    print(f"[=] ----+{hexadecimal_len*'-'}+{ascii_len*'-'}")
+
+    blocks = [bindata[i:i+blocksize] for i in range(0, len(bindata), blocksize)]
+    blk_index = 1
+    for b in blocks:
+        hexstr = ' '.join(b.hex()[i:i+2] for i in range(0, len(b.hex()), 2))
+        asciistr = ''.join([chr(b[i]) if (b[i] > 31 and b[i] < 127) else '.' for i in range(0,len(b),1)])
+        print(f"[=] {blk_index:3} | {hexstr.upper()} | {asciistr} ")
+        blk_index += 1
 
 def expect_response(accepted_responses: Union[int, list[int]]) -> Callable[..., Any]:
     """


### PR DESCRIPTION
**Thanks** to @taichunmin and @rickNmorty2 for the implementation and the enhancement of `fchk` and `dump` commands. 

#### Display memory function (xxd like)
Add `print_mem_dump(bindata, blocksize)` in `chameleon_util.py` to display memory content

#### Display chameleon MIFARE Classic emulation memory
Add `hf mf eview` to display emulation memory content

```
[USB] chameleon --> hf mf eview -s 1
[=] ----+-------------------------------------------------+-----------------
[=] blk | data                                            | ascii
[=] ----+-------------------------------------------------+-----------------
[=]   1 | C7 CF 0C 03 07 08 04 00 62 63 64 65 66 67 68 69 | ........bcdefghi 
[=]   2 | 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 | ................ 
[=]   3 | 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 | ................ 
[=]   4 | 00 00 00 00 00 00 FF 07 80 69 FF FF FF FF FF FF | .........i...... 
[=]   5 | 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 | ................ 
[=]   6 | 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 | ................
```
#### Display content from MIFARE Classic tag or dump file
Add `hf mf view` command to display content from:
- binary memory dump file using `--dump-file (-d)` 
- current tag specifying the file key exported with `fchk` using `--key-file (-k)`


```
[USB] chameleon --> hf mf view -d dump.bin
Reading dump file
[=] ----+-------------------------------------------------+-----------------
[=] blk | data                                            | ascii
[=] ----+-------------------------------------------------+-----------------
[=]   1 | C7 CF 0C 03 07 08 04 00 62 63 64 65 66 67 68 69 | ........bcdefghi 
[=]   2 | 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 | ................ 
[=]   3 | 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 | ................ 
[=]   4 | 00 00 00 00 00 00 FF 07 80 69 FF FF FF FF FF FF | .........i...... 
[=]   5 | 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 | ................
```
```
[USB] chameleon --> hf mf view --1k -k recovered_keys
Reading tag memory
[=] ----+-------------------------------------------------+-----------------
[=] blk | data                                            | ascii
[=] ----+-------------------------------------------------+-----------------
[=]   1 | C7 CF 0C 03 07 08 04 00 62 63 64 65 66 67 68 69 | ........bcdefghi 
[=]   2 | 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 | ................ 
[=]   3 | 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 | ................ 
[=]   4 | 00 00 00 00 00 00 FF 07 80 69 FF FF FF FF FF FF | .........i...... 
[=]   5 | 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 | ................
```
