### PR TITLE
fix-LF-emulation

### DIFF
--- a/firmware/application/src/rfid/nfctag/lf/lf_tag_em.c
+++ b/firmware/application/src/rfid/nfctag/lf/lf_tag_em.c
@@ -201,7 +201,8 @@ uint64_t em410x_id_to_memory64(uint8_t id[5]) {
  */
 bool lf_is_field_exists(void) {
     nrf_drv_lpcomp_enable();
-    bsp_delay_us(20);                                   // Display for a period of time and sampling to avoid misjudgment
+    // With 20ms of delay CU was not able to detect the field of my reader after waking up.
+    bsp_delay_us(30);                                   // Display for a period of time and sampling to avoid misjudgment
     nrf_lpcomp_task_trigger(NRF_LPCOMP_TASK_SAMPLE);    //Trigger a sampling
     return nrf_lpcomp_result_get() == 1;                //Determine the sampling results of the LF field status
 }
@@ -261,7 +262,14 @@ void timer_ce_handler(nrf_timer_event_t event_type, void *p_context) {
             if (m_is_send_first_edge == true) { // The first edge of the next sends next time
                 if (++m_bit_send_position >= LF_125KHZ_EM410X_BIT_SIZE) {
                     m_bit_send_position = 0;    // The broadcast is successful once, and the BIT position is zero
-                    if (++m_send_id_count >= LF_125KHZ_BROADCAST_MAX) {
+/* The main part of the idea. The original EM4100 tag continuously sends it's ID.
+* The root problem, in my point of view, was that CU started to "feel" the field too far to be able to modulate it deep enough,
+* and 3 times (LF_125KHZ_BROADCAST_MAX) of repeating takes only about 100ms, CU is still not close enough to the reader.
+* That is why the emulation worked only if the CU moved past the reader quickly (fly by).*/
+                    if(!lf_is_field_exists()){
+                        m_send_id_count++;
+                    }
+                    if (m_send_id_count >= LF_125KHZ_BROADCAST_MAX) {
                         m_send_id_count = 0;                                        //The number of broadcasts reaches the upper limit, re -identifies the status of the field and re -statistically count the number of broadcast times
                     }
                 }

--- a/firmware/application/src/rfid/nfctag/lf/lf_tag_em.c
+++ b/firmware/application/src/rfid/nfctag/lf/lf_tag_em.c
@@ -201,7 +201,6 @@ uint64_t em410x_id_to_memory64(uint8_t id[5]) {
  */
 bool lf_is_field_exists(void) {
     nrf_drv_lpcomp_enable();
-    // With 20ms of delay CU was not able to detect the field of my reader after waking up.
     bsp_delay_us(30);                                   // Display for a period of time and sampling to avoid misjudgment
     nrf_lpcomp_task_trigger(NRF_LPCOMP_TASK_SAMPLE);    //Trigger a sampling
     return nrf_lpcomp_result_get() == 1;                //Determine the sampling results of the LF field status
@@ -262,11 +261,7 @@ void timer_ce_handler(nrf_timer_event_t event_type, void *p_context) {
             if (m_is_send_first_edge == true) { // The first edge of the next sends next time
                 if (++m_bit_send_position >= LF_125KHZ_EM410X_BIT_SIZE) {
                     m_bit_send_position = 0;    // The broadcast is successful once, and the BIT position is zero
-/* The main part of the idea. The original EM4100 tag continuously sends its ID.
-* The root problem, in my point of view, was that CU started to "feel" the field too far to be able to modulate it deep enough,
-* and 3 times (LF_125KHZ_BROADCAST_MAX) of repeating takes only about 100ms, CU is still not close enough to the reader.
-* That is why the emulation worked only if the CU moved past the reader quickly (fly by).*/
-                    if(!lf_is_field_exists()){
+                    if(!lf_is_field_exists()){  // To avoid stopping sending when the reader field is present
                         m_send_id_count++;
                     }
                     if (m_send_id_count >= LF_125KHZ_BROADCAST_MAX) {

--- a/firmware/application/src/rfid/nfctag/lf/lf_tag_em.c
+++ b/firmware/application/src/rfid/nfctag/lf/lf_tag_em.c
@@ -262,7 +262,7 @@ void timer_ce_handler(nrf_timer_event_t event_type, void *p_context) {
             if (m_is_send_first_edge == true) { // The first edge of the next sends next time
                 if (++m_bit_send_position >= LF_125KHZ_EM410X_BIT_SIZE) {
                     m_bit_send_position = 0;    // The broadcast is successful once, and the BIT position is zero
-/* The main part of the idea. The original EM4100 tag continuously sends it's ID.
+/* The main part of the idea. The original EM4100 tag continuously sends its ID.
 * The root problem, in my point of view, was that CU started to "feel" the field too far to be able to modulate it deep enough,
 * and 3 times (LF_125KHZ_BROADCAST_MAX) of repeating takes only about 100ms, CU is still not close enough to the reader.
 * That is why the emulation worked only if the CU moved past the reader quickly (fly by).*/

--- a/firmware/application/src/rfid/nfctag/lf/lf_tag_em.h
+++ b/firmware/application/src/rfid/nfctag/lf/lf_tag_em.h
@@ -11,7 +11,6 @@
  * The definition of the packaging tool macro only needs to be modulated 0 and 1
  */
 #define LF_125KHZ_EM410X_BIT_SIZE   64
-// Have decided to increase the period of field sensing in this way
 #define LF_125KHZ_BROADCAST_MAX     10      // 32.768ms once, about 31 times in one second
 #define LF_125KHZ_EM410X_BIT_CLOCK  256
 #define LF_EM410X_TAG_ID_SIZE       5

--- a/firmware/application/src/rfid/nfctag/lf/lf_tag_em.h
+++ b/firmware/application/src/rfid/nfctag/lf/lf_tag_em.h
@@ -11,7 +11,8 @@
  * The definition of the packaging tool macro only needs to be modulated 0 and 1
  */
 #define LF_125KHZ_EM410X_BIT_SIZE   64
-#define LF_125KHZ_BROADCAST_MAX     3      // 32.768ms once, about 31 times in one second
+// Have decided to increase the period of field sensing in this way
+#define LF_125KHZ_BROADCAST_MAX     10      // 32.768ms once, about 31 times in one second
 #define LF_125KHZ_EM410X_BIT_CLOCK  256
 #define LF_EM410X_TAG_ID_SIZE       5
 


### PR DESCRIPTION
The original EM4100 tag continuously sends its ID.
The root problem, in my point of view, was that CU started to "feel" the field too far to be able to modulate it deep enough,
and 3 times (LF_125KHZ_BROADCAST_MAX) of repeating takes only about 100ms, CU is still not close enough to the reader.
That is why the emulation worked only if the CU moved past the reader quickly (fly by).