### PR TITLE
Add functionality behind --dic argument in CU CLI

### DIFF
--- a/software/script/chameleon_cli_unit.py
+++ b/software/script/chameleon_cli_unit.py
@@ -52,14 +52,6 @@ def check_tools():
         print(f'{CR}Warning, tools {", ".join(missing_tools)} not found. '
               f'Corresponding commands will not work as intended.{C0}')
 
-dict_keys = set()
-def load_dic_file(filename, keys):
-    #print("Read directory from", filename) ## debug
-    for dict_key in filename.readlines():
-        if not dict_key.startswith("#") and not dict_key is None:
-            dict_keys.add(dict_key)
-
-    return dict_keys
 
 class BaseCLIUnit:
     def __init__(self):
@@ -951,12 +943,17 @@ class HFMFFCHK(ReaderRequiredUnit):
                 return
 
         if args.import_dic is not None:
-            for key in load_dic_file(args.import_dic, keys):
-                if not re.match(r'^[a-fA-F0-9]{12}$', key):
+            for key in args.import_dic.readlines():
+                if key.startswith("#"): # ignore comments
+                    pass
+                elif key.isspace(): # ignore empty lines
+                    pass
+                elif re.match(r'^[a-fA-F0-9]{12}$', key): # take only this key format
+                    keys.add(bytes.fromhex(key))
+                else: # in case of another format, a conversion is needed
                     print(f' - {CR}Key should in hex[12] format, invalid key is ignored{C0}, key = "{key}"')
-                    continue            
-                keys.add(bytes.fromhex(key))
-
+                    continue
+                    
         if len(keys) == 0:
             print(f' - {CR}No keys{C0}')
             return
@@ -2495,7 +2492,7 @@ class HWSlotList(DeviceRequiredUnit):
                 print(f"{CY if enabled[fwslot]['hf'] else C0}{hf_tag_type}{C0}")
             else:
                 print("undef")
-            if (not args.short) and enabled[fwslot]['hf']:
+            if (not args.short) and enabled[fwslot]['hf'] and hf_tag_type != TagSpecificType.UNDEFINED:
                 if current != slot:
                     self.cmd.set_active_slot(slot)
                     current = slot
@@ -2546,7 +2543,7 @@ class HWSlotList(DeviceRequiredUnit):
                 print(f"{CY if enabled[fwslot]['lf'] else C0}{lf_tag_type}{C0}")
             else:
                 print("undef")
-            if (not args.short) and enabled[fwslot]['lf']:
+            if (not args.short) and enabled[fwslot]['lf'] and lf_tag_type != TagSpecificType.UNDEFINED:
                 if current != slot:
                     self.cmd.set_active_slot(slot)
                     current = slot

--- a/software/script/chameleon_cli_unit.py
+++ b/software/script/chameleon_cli_unit.py
@@ -52,6 +52,14 @@ def check_tools():
         print(f'{CR}Warning, tools {", ".join(missing_tools)} not found. '
               f'Corresponding commands will not work as intended.{C0}')
 
+dict_keys = set()
+def load_dic_file(filename, keys):
+    #print("Read directory from", filename) ## debug
+    for dict_key in filename.readlines():
+        if not dict_key.startswith("#") and not dict_key is None:
+            dict_keys.add(dict_key)
+
+    return dict_keys
 
 class BaseCLIUnit:
     def __init__(self):
@@ -943,8 +951,11 @@ class HFMFFCHK(ReaderRequiredUnit):
                 return
 
         if args.import_dic is not None:
-            if not load_dic_file(args.import_dic, keys):
-                return
+            for key in load_dic_file(args.import_dic, keys):
+                if not re.match(r'^[a-fA-F0-9]{12}$', key):
+                    print(f' - {CR}Key should in hex[12] format, invalid key is ignored{C0}, key = "{key}"')
+                    continue            
+                keys.add(bytes.fromhex(key))
 
         if len(keys) == 0:
             print(f' - {CR}No keys{C0}')


### PR DESCRIPTION
As someone wanted to use the --dict in CLI and got an error, the source shows the functions `load_key_file` and `load_dict_file` are not defined.
After some tests, I believe the functionality does not need to be an own function, it is easier to read and understand in one block while parsing the keys.

The `if ... elif ... else` construct is not very elegant, but works better for the different types of comparing as a `match ... case`. It is good to extend, if a .dic file (or single keys from a file) needs to be converted.