### PR TITLE
Fix when the dir conatains hardnested is read only

### DIFF
--- a/software/script/chameleon_cli_unit.py
+++ b/software/script/chameleon_cli_unit.py
@@ -1181,7 +1181,6 @@ class HFMFHardNested(ReaderRequiredUnit):
             # Run the process, redirecting stdout and stderr to the output file
             process = subprocess.Popen(
                 cmd_recover_list,
-                cwd=default_cwd, # Run from the bin directory
                 stdout=temp_output_file, # Redirect stdout to file
                 stderr=subprocess.STDOUT, # Redirect stderr to the same file as stdout
             )


### PR DESCRIPTION
When package for normal Linux distribution, the dir contains hardnested is often read only (/usr/bin, /usr/libexec).

Currently hardnested will fail in this case, because chameleon_cli_unit.py set cwd to the read only dir and hardnested [try to create temporary file in it][1]:

```
--- Hardnested Tool Finished (Exit Code: 1) ---
   Error: Hardnested exited with code 1. Check log: /tmp/hardnested_output_sctqeksv.log
   Output captured:
Error creating temporary file: Permission denied

 - HardNested attack failed to recover the key.
```

The absolute path of hardnested is already used, we don't need to set cwd.

[1]: https://github.com/RfidResearchGroup/ChameleonUltra/blob/303d2d31e10b0b57c6181f7396706a23d54b72d7/software/src/HardnestedRecovery/hardnested_main.c#L118-L119