### PR TITLE
Fix incorrect slot LED indication when switching via CLI

### DIFF
--- a/firmware/application/src/app_cmd.c
+++ b/firmware/application/src/app_cmd.c
@@ -24,11 +24,11 @@
 NRF_LOG_MODULE_REGISTER();
 
 
-static void change_slot_auto(uint8_t slot) {
+static void change_slot_auto(uint8_t slot_new) {
+    uint8_t slot_now = tag_emulation_get_slot();
     device_mode_t mode = get_device_mode();
-    tag_emulation_change_slot(slot, mode != DEVICE_MODE_READER);
-    light_up_by_slot();
-    set_slot_light_color(RGB_RED);
+    tag_emulation_change_slot(slot_new, mode != DEVICE_MODE_READER);
+    apply_slot_change(slot_now, slot_new);
 }
 
 static data_frame_tx_t *cmd_processor_get_app_version(uint16_t cmd, uint16_t status, uint16_t length, uint8_t *data) {

--- a/firmware/application/src/app_main.c
+++ b/firmware/application/src/app_main.c
@@ -522,14 +522,7 @@ static void cycle_slot(bool dec) {
     // Update status only if the new card slot switch is valid
     tag_emulation_change_slot(slot_new, true); // Tell the analog card module that we need to switch card slots
     // Go back to the color corresponding to the field enablement type
-    uint8_t color_now = get_color_by_slot(slot_now);
-    uint8_t color_new = get_color_by_slot(slot_new);
-    // Switching the light effect of the card slot
-    ledblink3(slot_now, color_now, slot_new, color_new);
-    // Switched the card slot, we need to re-light
-    light_up_by_slot();
-    // Then switch the color of the light again
-    set_slot_light_color(color_new);
+    apply_slot_change(slot_now, slot_new);
 }
 
 static void show_battery(void) {

--- a/firmware/application/src/rfid_main.c
+++ b/firmware/application/src/rfid_main.c
@@ -1,5 +1,6 @@
 #include <stdint.h>
 #include "rfid_main.h"
+#include "rgb_marquee.h"
 
 
 
@@ -82,6 +83,15 @@ void light_up_by_slot(void) {
 }
 
 /**
+ * @brief Apply visual and state changes after switching slot
+ */
+void apply_slot_change(uint8_t slot_now, uint8_t slot_new) {
+    uint8_t color_now = get_color_by_slot(slot_now);
+    uint8_t color_new = get_color_by_slot(slot_new);
+    ledblink3(slot_now, color_now, slot_new, color_new);
+}
+
+/**
  * @brief Function for get current device mode
  */
 device_mode_t get_device_mode(void) {
@@ -97,9 +107,11 @@ device_mode_t get_device_mode(void) {
 uint8_t get_color_by_slot(uint8_t slot) {
     tag_slot_specific_type_t tag_types;
     tag_emulation_get_specific_types_by_slot(slot, &tag_types);
-    if (tag_types.tag_hf != TAG_TYPE_UNDEFINED && tag_types.tag_lf != TAG_TYPE_UNDEFINED) {
+    bool enabled_lf = tag_emulation_slot_is_enabled(slot, TAG_SENSE_LF);
+    bool enabled_hf = tag_emulation_slot_is_enabled(slot, TAG_SENSE_HF);
+    if (tag_types.tag_hf != TAG_TYPE_UNDEFINED && tag_types.tag_lf != TAG_TYPE_UNDEFINED && enabled_hf && enabled_lf) {
         return 0;   // Dual -frequency card simulation, return R, indicate a dual -frequency card
-    } else if (tag_types.tag_hf != TAG_TYPE_UNDEFINED) {   //High -frequency simulation, return G
+    } else if (tag_types.tag_hf != TAG_TYPE_UNDEFINED && enabled_hf) {   //High -frequency simulation, return G
         return 1;
     } else {    // Low -frequency simulation, return B
         return 2;

--- a/firmware/application/src/rfid_main.h
+++ b/firmware/application/src/rfid_main.h
@@ -31,6 +31,7 @@ typedef enum {
 // functions define
 void init_leds(void);
 void light_up_by_slot(void);
+void apply_slot_change(uint8_t slot_now, uint8_t slot_new);
 void reader_mode_enter(void);
 void tag_mode_enter(void);
 device_mode_t get_device_mode(void);


### PR DESCRIPTION
Previously, using `hw slot change -s N` via the CLI would cause inconsistent LED colors:
- The LED for the newly selected slot turned on, but old slot LEDs remained lit.
- LED colors did not reflect the actual slot configuration (e.g., slot 3 LED showed red instead of blue).

Changes:
- Used `get_color_by_slot()` to determine correct color per slot based on enabled tag types.
- Modified `get_color_by_slot()` to also check if LF/HF sensing is enabled.

Switching slots via CLI now behaves consistently with button-based slot changes.

Closes #160