### PR TITLE
Restore Python 3.9 compatibility for Chameleon CLI

### DIFF
--- a/software/script/chameleon_cli_unit.py
+++ b/software/script/chameleon_cli_unit.py
@@ -421,7 +421,7 @@ class LFHIDIdArgsUnit(DeviceRequiredUnit):
         return parser
 
     @staticmethod
-    def check_limits(format: int, fc: int | None, cn: int | None, il: int | None, oem: int | None):
+    def check_limits(format: int, fc: Union[int, None], cn: Union[int, None], il: Union[int, None], oem: Union[int, None]):
         limits = {
             HIDFormat.H10301: [0xFF, 0xFFFF, 0, 0],
             HIDFormat.IND26: [0xFFF, 0xFFF, 0, 0],

--- a/software/script/chameleon_cmd.py
+++ b/software/script/chameleon_cmd.py
@@ -409,7 +409,7 @@ class ChameleonCMD:
                 resp.parsed['nts']['a'].append(
                     {
                         'nt': reconstruct_full_nt(resp.data, i),
-                        'nt_enc': int.from_bytes(resp.data[i + 3: i + 7]),
+                        'nt_enc': int.from_bytes(resp.data[i + 3: i + 7], byteorder='big'),
                         'parity': parity_to_str(resp.data[i + 2])
                     }
                 )
@@ -417,7 +417,7 @@ class ChameleonCMD:
                 resp.parsed['nts']['b'].append(
                     {
                         'nt': reconstruct_full_nt(resp.data, i + 7),
-                        'nt_enc': int.from_bytes(resp.data[i + 10: i + 14]),
+                        'nt_enc': int.from_bytes(resp.data[i + 10: i + 14], byteorder='big'),
                         'parity': parity_to_str(resp.data[i + 9])
                     }
                 )

--- a/software/script/chameleon_utils.py
+++ b/software/script/chameleon_utils.py
@@ -164,7 +164,7 @@ def prng_successor(x, n):
 
 
 def reconstruct_full_nt(response_data, offset):
-    nt = int.from_bytes(response_data[offset: offset + 2])
+    nt = int.from_bytes(response_data[offset: offset + 2], byteorder='big')
 
     return (nt << 16) | prng_successor(nt, 16)
 

--- a/software/script/tests/test_hard_acquire.py
+++ b/software/script/tests/test_hard_acquire.py
@@ -69,8 +69,8 @@ def test_hardnested_acquire():
         while data_check_index < len(acquire_datas):
             # Memory Layout: nt_enc1(4byte) - nt_enc2(4byte) - par(1byte)...
             # To integer
-            nt_enc1 = int.from_bytes(acquire_datas[data_check_index + 0:  data_check_index + 0 + 4])
-            nt_enc2 = int.from_bytes(acquire_datas[data_check_index + 4:  data_check_index + 4 + 4])
+            nt_enc1 = int.from_bytes(acquire_datas[data_check_index + 0:  data_check_index + 0 + 4], byteorder='big')
+            nt_enc2 = int.from_bytes(acquire_datas[data_check_index + 4:  data_check_index + 4 + 4], byteorder='big')
             par_enc = acquire_datas[data_check_index + 8]
             # check unique and sum
             hardnested_utils.check_nonce_unique_sum(nt_enc1, par_enc >> 4)


### PR DESCRIPTION
After the last few changes (#263, #267), the minimum Python version required to run the Chameleon CLI effectively became **3.11**, due to the use of:
* The Python 3.10+ type hint syntax `int | None`
* `int.from_bytes()` calls without the required `byteorder` argument (mandatory in < 3.11)

However, the CLI documentation still states Python 3.9 as the minimum supported version.

This PR restores compatibility with Python 3.9 by:
* Replacing `int | None` with `Union[int, None]` for type hints.
* Adding an explicit `byteorder='big'` argument to all `int.from_bytes()` calls.

This way, the documented Python 3.9 requirement remains accurate.
Alternatively, if Python 3.11+ is intended to be the new baseline, the documentation should be updated accordingly — but I suggest keeping compatibility where possible.

