### PR TITLE
fix error response of cmd MF1_CHECK_KEYS_ON_BLOCK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ This project uses the changelog in accordance with [keepchangelog](http://keepac
  - HID Prox support (@TeCHiScy)
  - Added cmd for fetching all slots nicks (@Foxushka)
  - Added `hf mf senested` for recovering keys from static encrypted cards via backdoor (https://eprint.iacr.org/2024/1275) (@Foxushka)
- - Added cmd for faster bulk key checking on one block (~33 keys per second) (@Foxushka)
+ - Added cmd for faster bulk key checking on one block (~33 keys per second) (@Foxushka, @taichunmin)
  - Added cmd to acquire nonces for static encrypted cards via backdoor (@Foxushka) 
  - Added `firmware/docker-compose.yml` to build firmware in local docker (@taichunmin)
  - Added cmd to acquire nonces for hardnested(Protocol doc need update) (@xianglin1998)

--- a/firmware/application/src/app_cmd.c
+++ b/firmware/application/src/app_cmd.c
@@ -390,7 +390,7 @@ static data_frame_tx_t *cmd_processor_mf1_check_keys_of_sectors(uint16_t cmd, ui
 }
 
 static data_frame_tx_t *cmd_processor_mf1_check_keys_on_block(uint16_t cmd, uint16_t status, uint16_t length, uint8_t *data) {
-    if (length < 3 || (length - 3) % 6 != 0) {
+    if (length < 9 || data[2] * 6 + 3 != length) {
         return data_frame_make(cmd, STATUS_PAR_ERR, 0, NULL);
     }
 
@@ -400,10 +400,6 @@ static data_frame_tx_t *cmd_processor_mf1_check_keys_on_block(uint16_t cmd, uint
         .keys_len = data[2],
         .keys = (mf1_key_t *) &data[3]
     };
-
-    if ((length - 3) / 6 != in.keys_len) {
-        return data_frame_make(cmd, STATUS_PAR_ERR, 0, NULL);
-    }
 
     mf1_toolbox_check_keys_on_block_out_t out;
     status = mf1_toolbox_check_keys_on_block(&in, &out);


### PR DESCRIPTION
When I implement the MF1_CHECK_KEYS_ON_BLOCK command in my JavaScript SDK, the error response for the command is incorrect.

/cc @Foxushka 