### PR TITLE
NTAG21x: Fix FAST_READ handling to include the end page

### DIFF
--- a/firmware/application/src/rfid/nfctag/hf/nfc_mf0_ntag.c
+++ b/firmware/application/src/rfid/nfctag/hf/nfc_mf0_ntag.c
@@ -682,7 +682,7 @@ static void handle_fast_read_command(uint8_t block_num, uint8_t end_block_num) {
 
     NRF_LOG_INFO("HANDLING FAST READ %02x %02x", block_num, end_block_num);
 
-    handle_any_read(block_num, end_block_num - block_num, block_max);
+    handle_any_read(block_num, end_block_num - block_num + 1, block_max);
 }
 
 static bool check_ro_lock_on_page(int block_num) {


### PR DESCRIPTION
According to [NTAG213/215/216 data sheet](https://www.nxp.com/docs/en/data-sheet/NTAG213_215_216.pdf) 10.3 FAST_READ:

> The FAST_READ command requires a start page address and an end page address and returns the all n*4 bytes of the addressed pages. For example if the start address is 03h and the end address is 07h then pages 03h, 04h, 05h, 06h **and 07h** are returned.

This pr fixed the issue that the end page is not returned.

**This fix is only tested for NTAG215, more tests are needed. (I don't have the ability to test it)**