### PR TITLE
Fix chameleon_cli_unit.check_tools check the wrong dir

### DIFF
--- a/software/script/chameleon_cli_unit.py
+++ b/software/script/chameleon_cli_unit.py
@@ -65,12 +65,11 @@ def load_dic_file(import_dic, keys):
 
 
 def check_tools():
-    bin_dir = Path.cwd() / "bin"
     missing_tools = []
 
     for tool in ("staticnested", "nested", "darkside", "mfkey32v2", "staticnested_1nt",
              "staticnested_2x1nt_rf08s", "staticnested_2x1nt_rf08s_1key"):
-        if any(bin_dir.glob(f"{tool}*")):
+        if any(default_cwd.glob(f"{tool}*")):
             continue
         else:
             missing_tools.append(tool)


### PR DESCRIPTION
Commit 35d2f40ff5801812c3517be89a4e1ad9c24b95ad introduce a breaking change, `chameleon_cli_unit.check_tools` check `bin` dir from pwd, instead of `bin` dir in the same dir of `chameleon_cli_unit.py`.

`python3 ./software/script/chameleon_cli_main.py` outputs wrong warning:

```
Warning, ... not found. Corresponding commands will not work as intended
```