### PR TITLE
Added support for Electra EM410X tags

### DIFF
--- a/firmware/application/src/app_cmd.c
+++ b/firmware/application/src/app_cmd.c
@@ -627,7 +627,7 @@ static data_frame_tx_t *cmd_processor_mf1_manipulate_value_block(uint16_t cmd, u
 }
 
 static data_frame_tx_t *cmd_processor_em410x_scan(uint16_t cmd, uint16_t status, uint16_t length, uint8_t *data) {
-    uint8_t card_buffer[7] = {0x00};
+    uint8_t card_buffer[15] = {0x00};
     status = scan_em410x(card_buffer);
     if (status != STATUS_LF_TAG_OK) {
         return data_frame_make(cmd, status, 0, NULL);

--- a/firmware/application/src/rfid/nfctag/lf/lf_tag_em.c
+++ b/firmware/application/src/rfid/nfctag/lf/lf_tag_em.c
@@ -268,7 +268,7 @@ bool lf_tag_data_factory(uint8_t slot, tag_specific_type_t tag_type, uint8_t *ta
  */
 bool lf_tag_em410x_data_factory(uint8_t slot, tag_specific_type_t tag_type) {
     // default id, must to align(4), more word...
-    uint8_t tag_id[5] = {0xDE, 0xAD, 0xBE, 0xEF, 0x88};
+    uint8_t tag_id[13] = {0xDE, 0xAD, 0xBE, 0xEF, 0x88, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
     return lf_tag_data_factory(slot, tag_type, tag_id, sizeof(tag_id));
 }
 

--- a/firmware/application/src/rfid/nfctag/lf/lf_tag_em.h
+++ b/firmware/application/src/rfid/nfctag/lf/lf_tag_em.h
@@ -5,7 +5,7 @@
 #include "rfid_main.h"
 #include "tag_emulation.h"
 
-#define LF_EM410X_TAG_ID_SIZE 5
+#define LF_EM410X_TAG_ID_SIZE 13
 #define LF_HIDPROX_TAG_ID_SIZE 13
 #define LF_VIKING_TAG_ID_SIZE 4
 

--- a/software/script/chameleon_cli_unit.py
+++ b/software/script/chameleon_cli_unit.py
@@ -405,8 +405,8 @@ class LFEMIdArgsUnit(DeviceRequiredUnit):
     def before_exec(self, args: argparse.Namespace):
         if not super().before_exec(args):
             return False
-        if args.id is None or not re.match(r"^[a-fA-F0-9]{10}$", args.id):
-            raise ArgsParserError("ID must include 10 HEX symbols")
+        if args.id is None or not re.match(r"^[a-fA-F0-9]{26}$", args.id):
+            raise ArgsParserError("ID must include 26 HEX symbols")
         return True
 
     def args_parser(self) -> ArgumentParserNoExit:

--- a/software/script/chameleon_cmd.py
+++ b/software/script/chameleon_cmd.py
@@ -434,7 +434,7 @@ class ChameleonCMD:
         """
         resp = self.device.send_cmd_sync(Command.EM410X_SCAN)
         if resp.status == Status.LF_TAG_OK:
-            resp.parsed = struct.unpack('!h5s', resp.data) # tag type + uid
+            resp.parsed = struct.unpack('!h13s', resp.data) # tag type + uid
         return resp
 
     @expect_response(Status.LF_TAG_OK)
@@ -599,9 +599,9 @@ class ChameleonCMD:
         :param id_bytes: byte of the card number
         :return:
         """
-        if len(id) != 5:
-            raise ValueError("The id bytes length must equal 5")
-        data = struct.pack('5s', id)
+        if len(id) != 13:
+            raise ValueError("The id bytes length must equal 13")
+        data = struct.pack('13s', id)
         return self.device.send_cmd_sync(Command.EM410X_SET_EMU_ID, data)
 
     @expect_response(Status.SUCCESS)


### PR DESCRIPTION
Fixes #203 

Electra tags transmit another 64bit packet (epilogue) after the standard EM410X data. This PR is loosly based on [flipperzero-firmware](https://github.com/flipperdevices/flipperzero-firmware/blob/dev/lib/lfrfid/protocols/protocol_electra.c).

During testing I discovered a tag that contained non-repeating data in the full 8 bytes epilogue, contrary to what the Flipper code comments suggests. Because of this, I chose to save the full epilogue rather than the first 2 bytes. Interestingly, even though the tag had 8 bytes of data, only the first 2 were checked by the intercom, so the flipper still managed to succesfully emulate the tag.

This PR has been successfully tested on multiple Electra intercoms (all installed after 2010). I do not have access to any other EM410X tags so I can't confirm the code is regression-free. I do not have access to blank EM410X tags so cannot verify whether Electra tags can be sucessfully written to a blank tag.

**Important note**: this PR changes the length of decoded data for EM410X tags to 13 bytes. However, the Android app only saves the 5 bytes of decoded data for EM410X tags. If you'd like to test this PR before it's merged you have to use the cli app from the artifacts below.