### PR TITLE
Fix error in `lf em 410x read` from color_string()

### DIFF
--- a/software/script/chameleon_cli_unit.py
+++ b/software/script/chameleon_cli_unit.py
@@ -3135,7 +3135,7 @@ class LFEMRead(ReaderRequiredUnit):
 
     def on_exec(self, args: argparse.Namespace):
         data = self.cmd.em410x_scan()
-        print(color_string((TagSpecificType(data[0])), (CG, data[1].hex())))
+        print(f"{TagSpecificType(data[0])}: {color_string((CG, data[1].hex()))}")
 
 
 @lf_em_410x.command('write')


### PR DESCRIPTION
Fix bug in color_string() usage introduced by 35d2f40 (bug #295).