### PR TITLE
Extend HID Prox scan with match info and GUI compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ This project uses the changelog in accordance with [keepchangelog](http://keepac
  - Added cmd for set mf1 config 'field_off_do_reset' (@xianglin1998)
  - Fix Windows build (@suut)
  - Added `hf 14a config` to deal with badly configured cards (@azuwis)
- - HID Prox: add 32-B format support, optional scan flags for match metadata, and match confidence in CLI (@vidonnus)
+ - HID Prox: add 32-B format support, optional scan flags for match metadata, match confidence in CLI, and fix FSK2a timing for all HID Prox formats (@vidonnus)
 
 ## [v2.1.0][2025-09-02]
  - Added UV, formatter and linter. Contribution guidelines. (@GameTec-live)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ This project uses the changelog in accordance with [keepchangelog](http://keepac
  - Added cmd for set mf1 config 'field_off_do_reset' (@xianglin1998)
  - Fix Windows build (@suut)
  - Added `hf 14a config` to deal with badly configured cards (@azuwis)
- - HID Prox: add optional scan flags for match metadata, align HPP32 packing with Proxmark3, and show match confidence in CLI (@vidonnus)
+ - HID Prox: add 32-B format support, optional scan flags for match metadata, and match confidence in CLI (@vidonnus)
 
 ## [v2.1.0][2025-09-02]
  - Added UV, formatter and linter. Contribution guidelines. (@GameTec-live)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This project uses the changelog in accordance with [keepchangelog](http://keepac
  - Added cmd for set mf1 config 'field_off_do_reset' (@xianglin1998)
  - Fix Windows build (@suut)
  - Added `hf 14a config` to deal with badly configured cards (@azuwis)
+ - HID Prox: add optional scan flags for match metadata, align HPP32 packing with Proxmark3, and show match confidence in CLI (@vidonnus)
 
 ## [v2.1.0][2025-09-02]
  - Added UV, formatter and linter. Contribution guidelines. (@GameTec-live)

--- a/firmware/application/src/rfid/nfctag/lf/protocols/hidprox.h
+++ b/firmware/application/src/rfid/nfctag/lf/protocols/hidprox.h
@@ -4,7 +4,7 @@
 #include "utils/fskdemod.h"
 #include "wiegand.h"
 
-#define HIDPROX_DATA_SIZE (16)
+#define HIDPROX_DATA_SIZE (80)
 
 typedef enum {
     STATE_SOF,

--- a/firmware/application/src/rfid/nfctag/lf/protocols/wiegand.c
+++ b/firmware/application/src/rfid/nfctag/lf/protocols/wiegand.c
@@ -328,14 +328,14 @@ static uint64_t pack_hpp32(wiegand_card_t *card) {
     uint64_t bits = PREAMBLE_32BIT;
     bits <<= 1;
     bits = (bits << 12) | (card->facility_code & 0xfff);
-    bits = (bits << 19) | ((card->card_number >> 10) & 0x7ffff);
+    bits = (bits << 19) | (card->card_number & 0x7ffff);
     return bits;
 }
 
 static wiegand_card_t *unpack_hpp32(uint64_t hi, uint64_t lo) {
     wiegand_card_t *d = wiegand_card_alloc();
     d->facility_code = (lo >> 19) & 0xfff;
-    d->card_number = ((lo >> 0) & 0x7ffff) << 10;
+    d->card_number = (lo >> 0) & 0x7ffff;
     return d;
 }
 
@@ -883,7 +883,7 @@ static const card_format_table_t formats[] = {
     {ATSW30, pack_atsw30, unpack_atsw30, 30, {1, 0xFFF, 0xFFFF, 0, 0}},          // ATS Wiegand 30-bit
     {ADT31, pack_adt31, unpack_adt31, 31, {0, 0xF, 0x7FFFFF, 0, 0}},             // HID ADT 31-bit
     {HCP32, pack_hcp32, unpack_hcp32, 32, {0, 0, 0x3FFF, 0, 0}},                 // HID Check Point 32-bit
-    {HPP32, pack_hpp32, unpack_hpp32, 32, {0, 0xFFF, 0x1FFFFFFF, 0, 0}},         // HID Hewlett-Packard 32-bit
+    {HPP32, pack_hpp32, unpack_hpp32, 32, {0, 0xFFF, 0x7FFFF, 0, 0}},            // HID Hewlett-Packard 32-bit
     {KASTLE, pack_kastle, unpack_kastle, 32, {1, 0xFF, 0xFFFF, 0x1F, 0}},        // Kastle 32-bit
     {KANTECH, pack_kantech, unpack_kantech, 32, {0, 0xFF, 0xFFFF, 0, 0}},        // Indala/Kantech KFS 32-bit
     {WIE32, pack_wie32, unpack_wie32, 32, {0, 0xFFF, 0xFFFF, 0, 0}},             // Wiegand 32-bit

--- a/firmware/application/src/rfid/nfctag/lf/protocols/wiegand.h
+++ b/firmware/application/src/rfid/nfctag/lf/protocols/wiegand.h
@@ -73,6 +73,7 @@ typedef enum {
     AVIG56,
     IR56,
     ACTPHID,
+    B32,
 } card_format_t;
 
 // Structure for defined Wiegand card formats available for packing/unpacking

--- a/firmware/application/src/rfid/nfctag/lf/protocols/wiegand.h
+++ b/firmware/application/src/rfid/nfctag/lf/protocols/wiegand.h
@@ -84,6 +84,23 @@ typedef struct {
     card_format_descriptor_t fields;
 } card_format_table_t;
 
+#define WIEGAND_MATCH_MAX_FORMATS (5)
+
+typedef struct {
+    uint8_t format;
+    uint8_t has_parity;
+    uint8_t fixed_mismatches;
+    uint64_t repacked;
+} wiegand_match_entry_t;
+
+typedef struct {
+    uint8_t valid;
+    uint8_t count;
+    uint64_t raw;
+    wiegand_match_entry_t entries[WIEGAND_MATCH_MAX_FORMATS];
+} wiegand_match_info_t;
+
 extern uint64_t pack(wiegand_card_t *card);
 extern wiegand_card_t *unpack(uint8_t format_hint, uint8_t length, uint64_t hi, uint64_t lo);
 extern wiegand_card_t *wiegand_card_alloc();
+extern bool wiegand_get_match_info(wiegand_match_info_t *out);

--- a/software/script/chameleon_cli_unit.py
+++ b/software/script/chameleon_cli_unit.py
@@ -444,6 +444,7 @@ class LFHIDIdArgsUnit(DeviceRequiredUnit):
             HIDFormat.KASTLE: [0xFF, 0xFFFF, 0x1F, 0],
             HIDFormat.KANTECH: [0xFF, 0xFFFF, 0, 0],
             HIDFormat.WIE32: [0xFFF, 0xFFFF, 0, 0],
+            HIDFormat.B32: [0x3FFF, 0xFFFF, 0, 0],
             HIDFormat.D10202: [0x7F, 0xFFFFFF, 0, 0],
             HIDFormat.H10306: [0xFFFF, 0xFFFF, 0, 0],
             HIDFormat.N10002: [0xFFFF, 0xFFFF, 0, 0],

--- a/software/script/chameleon_cli_unit.py
+++ b/software/script/chameleon_cli_unit.py
@@ -440,7 +440,7 @@ class LFHIDIdArgsUnit(DeviceRequiredUnit):
             HIDFormat.ATSW30: [0xFFF, 0xFFFF, 0, 0],
             HIDFormat.ADT31: [0xF, 0x7FFFFF, 0, 0],
             HIDFormat.HCP32: [0, 0x3FFF, 0, 0],
-            HIDFormat.HPP32: [0xFFF, 0x1FFFFFFF, 0, 0],
+            HIDFormat.HPP32: [0xFFF, 0x7FFFF, 0, 0],
             HIDFormat.KASTLE: [0xFF, 0xFFFF, 0x1F, 0],
             HIDFormat.KANTECH: [0xFF, 0xFFFF, 0, 0],
             HIDFormat.WIE32: [0xFFF, 0xFFFF, 0, 0],

--- a/software/script/chameleon_enum.py
+++ b/software/script/chameleon_enum.py
@@ -599,6 +599,7 @@ class HIDFormat(enum.IntEnum):
     P10004 = 28
     HGEN37 = 29
     MDI37 = 30
+    B32 = 43
 
     def __str__(self):
         descriptions = {
@@ -633,6 +634,7 @@ class HIDFormat(enum.IntEnum):
             HIDFormat.P10004: "HID P10004 37-bit PCSC",
             HIDFormat.HGEN37: "HID Generic 37-bit",
             HIDFormat.MDI37: "PointGuard MDI 37-bit",
+            HIDFormat.B32: "32-B 32-bit",
         }
         if self in descriptions:
             return descriptions[self]


### PR DESCRIPTION
## Summary
- Extend HIDPROX_SCAN with an optional flags byte to return match metadata without breaking legacy clients.
- Add 32-B format support (EP + 14-bit FC + 16-bit CN + OP).
- Fix 32-bit format auto-detection regression (scope repack validation to 32-bit scoring only, preventing ADT31 false rejections).
- Fix FSK2a timing for all HID Prox formats (add remainder tracking to correct fc/8 wave timing, matching Proxmark3 behavior).
- CLI now displays all matching formats with confidence when no format hint is provided.

## Related Issues
- Closes #359

## Testing
- Built firmware locally.
- Verified `lf hid prox read` output with match list and 32-B detection.
- Verified ChameleonUltraGui BLE read path (zero-length payload compatibility).
- Confirmed ADT31 detection not affected by validation changes.