### PR TITLE
Fix `param error` of `hf mf esave`

### DIFF
--- a/software/script/chameleon_cli_unit.py
+++ b/software/script/chameleon_cli_unit.py
@@ -2307,7 +2307,7 @@ class HFMFESave(SlotIndexArgsAndGoUnit, DeviceRequiredUnit):
         data = bytearray(0)
         max_blocks = self.device_com.data_max_length // 16
         while block_count > 0:
-            chunk_count = min(block_count, max_blocks)
+            chunk_count = min(block_count, max_blocks, 32)
             data.extend(self.cmd.mf1_read_emu_block_data(index, chunk_count))
             index += chunk_count
             block_count -= chunk_count


### PR DESCRIPTION
Step to reproduce:

```
[USB] chameleon --> hf mf esave -f test.bin
API request fail, param error
```

Commit d95112f8211ae1d9cb01868abbb559d0dbb2d3fb change NETDATA_MAX_DATA_LENGTH from 512 to 4096, this increase max block count to 256, while [cmd_processor_mf1_read_emu_block_data][1] hardcode max block count to 32

[1]: https://github.com/RfidResearchGroup/ChameleonUltra/blob/b108c84af9b473c840ddcae6f769502adb6c5aa5/firmware/application/src/app_cmd.c#L1088