### PR TITLE
fix: use native winpthreads for MinGW/MSYS2 Windows builds

### DIFF
--- a/software/src/CMakeLists.txt
+++ b/software/src/CMakeLists.txt
@@ -97,14 +97,21 @@ elseif (CMAKE_SYSTEM_NAME MATCHES "Windows")
         endif()
     endif()
 
-    FetchContent_Declare(
-        pthreads4w
-        GIT_REPOSITORY "https://github.com/GerHobbelt/pthread-win32"
-        OVERRIDE_FIND_PACKAGE
-        EXCLUDE_FROM_ALL
-    )
-    find_package(pthreads4w CONFIG REQUIRED)
-    set(LIBTHREAD pthreads4w::pthreadVC3)
+    if(MSVC)
+        # MSVC has no native POSIX threads; use pthreads4w
+        FetchContent_Declare(
+            pthreads4w
+            GIT_REPOSITORY "https://github.com/GerHobbelt/pthread-win32"
+            OVERRIDE_FIND_PACKAGE
+            EXCLUDE_FROM_ALL
+        )
+        find_package(pthreads4w CONFIG REQUIRED)
+        set(LIBTHREAD pthreads4w::pthreadVC3)
+    else()
+        # MinGW/MSYS2 ships with winpthreads; use native threads
+        find_package(Threads REQUIRED)
+        set(LIBTHREAD Threads::Threads)
+    endif()
 
     set(LIBMATH "") # No separate math library needed on Windows
 else()


### PR DESCRIPTION
## Summary

Fixes #378

The `pthreads4w` dependency is fetched for **all** Windows builds, but its CMake architecture detection uses MSVC-specific macros (`_M_X64`, `_M_IX86`). Under MinGW/MSYS2/ProxSpace these macros don't exist, causing:

```
CMake Error at _deps/pthreads4w-src/CMakeLists.txt:29 (message):
  "unknown" not supported in version.rc
```

## Changes

Split the Windows threading logic in `software/src/CMakeLists.txt`:
- **MSVC** → keeps using `pthreads4w` (unchanged)
- **MinGW/MSYS2** → uses native `find_package(Threads)` via winpthreads (bundled with MinGW-w64)

No source code changes needed — all files use standard POSIX pthreads API.

## Testing

Reproduced and verified on Windows 11 with MSYS2/MinGW-w64 (GCC 15.2.0):

1. **Before fix:** `cmake .. -G "MinGW Makefiles"` fails with `"unknown" not supported in version.rc`
2. **After fix:** CMake configures successfully, all 11 targets build to completion (nested, staticnested, darkside, mfkey32, mfkey32v2, mfkey64, staticnested_1nt, staticnested_2x1nt_rf08s, staticnested_2x1nt_rf08s_1key, mfulc_des_brute, hardnested)

MSVC builds are unaffected as the pthreads4w path remains unchanged for `if(MSVC)`.