### PR TITLE
Fix firmware application USB serial number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project uses the changelog in accordance with [keepchangelog](http://keepachangelog.com/). Please use this to write notable changes, which is not the same as git commit log...
 
 ## [unreleased][unreleased]
+ - Fix firmware application USB serial number (@taichunmin)
  - Added ioProx LF protocol support (read, emulate and T55xx clone)
  - Added commands to dump and clone Mifare tags
  - Fix bad missing tools warning (@suut)

--- a/firmware/application/src/sdk_config.h
+++ b/firmware/application/src/sdk_config.h
@@ -6614,7 +6614,7 @@
 
 
 #ifndef APP_USBD_STRING_SERIAL_EXTERN
-#define APP_USBD_STRING_SERIAL_EXTERN 0
+#define APP_USBD_STRING_SERIAL_EXTERN 1
 #endif
 
 // <s> APP_USBD_STRING_SERIAL - String descriptor for the serial number.
@@ -6622,7 +6622,7 @@
 // <i> Note: This value is not editable in Configuration Wizard.
 // <i> Serial number that is defined the same way like in @ref APP_USBD_STRINGS_MANUFACTURER.
 #ifndef APP_USBD_STRING_SERIAL
-#define APP_USBD_STRING_SERIAL APP_USBD_STRING_DESC("000000000000")
+#define APP_USBD_STRING_SERIAL g_extern_serial_number
 #endif
 
 // </e>


### PR DESCRIPTION
Fix the USB serial number to distinguish difference devices.

Following is the port info before fix:

```js
[
  { // application
    path: '/dev/tty.usbmodem0000000000001',
    manufacturer: 'Proxgrind',
    serialNumber: '000000000000',
    pnpId: undefined,
    locationId: '14110000',
    vendorId: '6868',
    productId: '8686'
  },
  { // bootloader
    path: '/dev/tty.usbmodemD859C13EE4AD1',
    manufacturer: 'Proxgrind',
    serialNumber: 'D859C13EE4AD',
    pnpId: undefined,
    locationId: '14110000',
    vendorId: '1915',
    productId: '521f'
  }
]
```