### PR TITLE
feat(cli): integrate HardNested attack into autopwn

### DIFF
--- a/software/script/chameleon_cli_unit.py
+++ b/software/script/chameleon_cli_unit.py
@@ -2440,9 +2440,43 @@ class HFMFAutopwn(ReaderRequiredUnit):
 
         print(f" {CG}[+]{C0}  Some keys found, recovering remaining..")
         if nt_level == 2:
-            print(
-                f" {CY}[+]{C0}  Hardened card — use 'hf mf hardnested' to recover remaining keys"
-            )
+            missing_keys = self.find_missing_keys(current_keys_found, total)
+            hardnested = HFMFHardNested.__new__(HFMFHardNested)
+            BaseCLIUnit.__init__(hardnested)
+            hardnested._device_cmd = self.cmd
+            for missing_key_num, key_type_target in missing_keys.items():
+                if current_keys_found.get(missing_key_num) is not None:
+                    print(f" {CG}[+]{C0}  Key {missing_key_num} found by reuse")
+                    continue
+                block_known, key_known_bytes, type_known = self.choose_random_known_key(
+                    current_keys_found
+                )
+                block_target = (missing_key_num // 2) * 4
+                hn_key = hardnested.recover_key(
+                    False,
+                    block_known,
+                    type_known,
+                    key_known_bytes,
+                    block_target,
+                    key_type_target,
+                    False,
+                    200,
+                    3,
+                )
+                if hn_key is None:
+                    continue
+                print(f" {CG}[+]{C0}  Found key {missing_key_num}: {hn_key.upper()}")
+                current_keys_found[missing_key_num] = bytes.fromhex(hn_key)
+                current_keys_found = dict(sorted(current_keys_found.items()))
+                _, mask_bytes = self.mask_from_keys(missing_keys)
+                current_keys_found = self.merge_found_sector_keys(
+                    current_keys_found,
+                    self.try_key(bytes.fromhex(hn_key), self.neg_bytes(mask_bytes)),
+                )
+            if len(current_keys_found) < total:
+                current_keys_found = self.run_senested(
+                    current_keys_found, max_sectors_num
+                )
         elif nt_level == 0:
             current_keys_found = self.run_senested(current_keys_found, max_sectors_num)
         else:


### PR DESCRIPTION
When autopwn detects a HardNested vulnerable card (nt_level=2) with some known keys, it now automatically attempts to recover remaining keys using the hardnested attack, instead of only printing an advisory message. 

The implementation:
- Iterates over each missing key slot, picking a known key before each attempt (allows newly recovered keys to be reused for subsequent targets)
- Invokes hardnested.recover_key() with standard parameters (200 max runs, 3 max attempts)
- After each found key, checks if it is reusable for other sectors
- Falls back to senested attack if hardnested does not recover all keys

This matches the existing behavior for nested and static-encrypted-nested attacks.