### PR TITLE
Add iOS client "MCT Mifare Chameleon Tool" to compatible applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Read the [available documentation](https://github.com/RfidResearchGroup/Chameleo
 
 * [ChameleonUltraGUI](https://github.com/GameTec-live/ChameleonUltraGUI)
 * [MTools BLE](https://github.com/RfidResearchGroup/ChameleonUltra/wiki/mtoolsble)
+* [Mifare Chameleon Tool (iOS)](https://apps.apple.com/it/app/mifare-chameleon-tool/id6761231484)
 
 # Videos
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Read the [available documentation](https://github.com/RfidResearchGroup/Chameleo
 
 * [ChameleonUltraGUI](https://github.com/GameTec-live/ChameleonUltraGUI)
 * [MTools BLE](https://github.com/RfidResearchGroup/ChameleonUltra/wiki/mtoolsble)
-* [Mifare Chameleon Tool (iOS)](https://apps.apple.com/it/app/mifare-chameleon-tool/id6761231484)
+* [Mifare Chameleon Tool (iOS)](https://apps.apple.com/it/app/mifare-chameleon-tool/id6761231484) 
 
 # Videos
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Read the [available documentation](https://github.com/RfidResearchGroup/Chameleo
 
 * [ChameleonUltraGUI](https://github.com/GameTec-live/ChameleonUltraGUI)
 * [MTools BLE](https://github.com/RfidResearchGroup/ChameleonUltra/wiki/mtoolsble)
-* [Mifare Chameleon Tool (iOS)](https://apps.apple.com/it/app/mifare-chameleon-tool/id6761231484) 
+* [Mifare Chameleon Tool (iOS only, Beta)](https://apps.apple.com/it/app/mifare-chameleon-tool/id6761231484) 
 
 # Videos
 


### PR DESCRIPTION
Hi,

I would like to add my iOS application "Mifare Chameleon Tool" to the list of compatible applications.

App Store link:
https://apps.apple.com/it/app/mifare-chameleon-tool/id6761231484

This app provides an iOS client for Chameleon Ultra over BLE, allowing users to interact with the device directly from iPhone.

Main features include:
- Tag interaction (read/write)
- Basic emulation handling
- BLE communication with Chameleon Ultra
- Workflow similar to Mifare Classic Tool (MCT)

This can be useful especially for iOS users, where currently there are limited options compared to Android.

The app has been tested with Chameleon Ultra and works correctly.

Since the app is paid, I am available to provide free redeem codes for maintainers for testing and evaluation.

I can also provide screenshots or additional technical details if needed.

Thanks for your work on this project!