### PR TITLE
fix: hf mf eview param error due to chunk exceeding 32-block limit

### DIFF
--- a/software/script/chameleon_cli_unit.py
+++ b/software/script/chameleon_cli_unit.py
@@ -3798,7 +3798,7 @@ class HFMFEView(SlotIndexArgsAndGoUnit, DeviceRequiredUnit):
         max_blocks = self.device_com.data_max_length // 16
         while block_count > 0:
             # read all the blocks
-            chunk_count = min(block_count, max_blocks)
+            chunk_count = min(block_count, max_blocks, 32)
             data.extend(self.cmd.mf1_read_emu_block_data(index, chunk_count))
             index += chunk_count
             block_count -= chunk_count


### PR DESCRIPTION
The firmware limits mf1_read_emu_block_data to at most 32 blocks per request, but eview's chunk_count only honored data_max_length (256). Added the same 32-block cap already used by esave.

Fix #412