### PR TITLE
Align hf 14a raw CLI parameters with proxmark3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 This project uses the changelog in accordance with [keepchangelog](http://keepachangelog.com/). Please use this to write notable changes, which is not the same as git commit log...
 
 ## [unreleased][unreleased]
+ - Changed `hf 14a raw` CLI parameters to align with Proxmark3: replaced `-d`/`--data` with positional hex args, added `-3`/`--no-rats`, `-v`/`--verbose` (@azuwis)
+ - Added `no_rats` parameter to `hf 14a raw` for ISO14443-3 select only (skip RATS) (@azuwis)
  - Added PAC/Stanley LF protocol support: read, emulate and T55xx clone (@kevihiiin, @danieltwagner)
  - Fix firmware application USB serial number (@taichunmin)
  - Added ioProx LF protocol support (read, emulate and T55xx clone)

--- a/firmware/application/src/app_cmd.c
+++ b/firmware/application/src/app_cmd.c
@@ -551,7 +551,8 @@ static data_frame_tx_t *cmd_processor_hf14a_raw(uint16_t cmd, uint16_t status, u
 
     typedef struct {
         struct { // LSB -> MSB
-            uint8_t reserved : 2;
+            uint8_t reserved : 1;
+            uint8_t no_rats : 1;
 
             uint8_t check_response_crc : 1;
             uint8_t keep_rf_field : 1;
@@ -578,6 +579,7 @@ static data_frame_tx_t *cmd_processor_hf14a_raw(uint16_t cmd, uint16_t status, u
     NRF_LOG_INFO("auto_select        = %d", payload->options.auto_select);
     NRF_LOG_INFO("keep_rf_field      = %d", payload->options.keep_rf_field);
     NRF_LOG_INFO("check_response_crc = %d", payload->options.check_response_crc);
+    NRF_LOG_INFO("no_rats            = %d", payload->options.no_rats);
     NRF_LOG_INFO("reserved           = %d", payload->options.reserved);
 
     status = pcd_14a_reader_raw_cmd(
@@ -587,6 +589,7 @@ static data_frame_tx_t *cmd_processor_hf14a_raw(uint16_t cmd, uint16_t status, u
                  payload->options.auto_select,
                  payload->options.keep_rf_field,
                  payload->options.check_response_crc,
+                 payload->options.no_rats,
 
                  U16NTOHS(payload->resp_timeout),
 

--- a/firmware/application/src/rfid/reader/hf/rc522.c
+++ b/firmware/application/src/rfid/reader/hf/rc522.c
@@ -1456,7 +1456,7 @@ inline void pcd_14a_reader_crc_computer(uint8_t use522CalcCRC) {
 * @retval   : Execution Status
 *
 */
-uint8_t pcd_14a_reader_raw_cmd(bool openRFField,  bool waitResp, bool appendCrc, bool autoSelect, bool keepField, bool checkCrc, uint16_t waitRespTimeout,
+uint8_t pcd_14a_reader_raw_cmd(bool openRFField,  bool waitResp, bool appendCrc, bool autoSelect, bool keepField, bool checkCrc, bool noRats, uint16_t waitRespTimeout,
                                uint16_t szDataSendBits, uint8_t *pDataSend, uint8_t *pDataRecv, uint16_t *pszDataRecv, uint16_t szDataRecvBitMax) {
     // Status code, default is OK.
     uint8_t status = STATUS_HF_TAG_OK;
@@ -1496,7 +1496,12 @@ uint8_t pcd_14a_reader_raw_cmd(bool openRFField,  bool waitResp, bool appendCrc,
 
     if (autoSelect) {
         picc_14a_tag_t ti;
+        int8_t saved_forcerats = hf14aconfig.forcerats;
+        if (noRats) {
+            hf14aconfig.forcerats = 2;  // skip RATS
+        }
         status = pcd_14a_reader_scan_once(&ti);
+        hf14aconfig.forcerats = saved_forcerats;
         // Determine whether the card search was successful
         if (status != STATUS_HF_TAG_OK) {
             pcd_14a_reader_antenna_off();

--- a/firmware/application/src/rfid/reader/hf/rc522.h
+++ b/firmware/application/src/rfid/reader/hf/rc522.h
@@ -247,7 +247,7 @@ uint8_t pcd_14a_reader_mf1_transfer_value_block(uint8_t addr);
 uint8_t pcd_14a_reader_halt_tag(void);
 void pcd_14a_reader_fast_halt_tag(void);
 
-uint8_t pcd_14a_reader_raw_cmd(bool openRFField, bool waitResp, bool appendCrc, bool autoSelect, bool keepField, bool checkCrc, uint16_t waitRespTimeout,
+uint8_t pcd_14a_reader_raw_cmd(bool openRFField, bool waitResp, bool appendCrc, bool autoSelect, bool keepField, bool checkCrc, bool noRats, uint16_t waitRespTimeout,
                                uint16_t szDataSendBits, uint8_t *pDataSend, uint8_t *pDataRecv, uint16_t *pszDataRecv, uint16_t szDataRecvBitMax);
 
 // UID & UFUID tag operation

--- a/software/script/chameleon_cli_unit.py
+++ b/software/script/chameleon_cli_unit.py
@@ -7167,7 +7167,7 @@ class HF14ARaw(ReaderRequiredUnit):
     def args_parser(self) -> ArgumentParserNoExit:
         parser = ArgumentParserNoExit()
         parser.formatter_class = argparse.RawDescriptionHelpFormatter
-        parser.description = "Send raw command"
+        parser.description = "Send raw hex data to tag"
         parser.add_argument(
             "-a",
             "--activate-rf",
@@ -7182,10 +7182,12 @@ class HF14ARaw(ReaderRequiredUnit):
             action="store_true",
             default=False,
         )
-        # TODO: parser.add_argument('-3', '--type3-select-tag',
-        #           help="Active signal field ON with ISO14443-3 select (no RATS)", action='store_true', default=False,)
         parser.add_argument(
-            "-d", "--data", type=str, metavar="<hex>", help="Data to be sent"
+            "-3",
+            "--no-rats",
+            help="ISO14443-3 select only (skip RATS)",
+            action="store_true",
+            default=False,
         )
         parser.add_argument(
             "-b",
@@ -7226,16 +7228,30 @@ class HF14ARaw(ReaderRequiredUnit):
             "-t",
             "--timeout",
             type=int,
-            metavar="<dec>",
+            metavar="<ms>",
             help="Timeout in ms",
             default=100,
         )
+        parser.add_argument(
+            "-v",
+            "--verbose",
+            help="Verbose output",
+            action="store_true",
+            default=False,
+        )
+        parser.add_argument(
+            "data",
+            nargs="*",
+            metavar="<hex>",
+            help="Raw bytes to send (hex string, can be multiple args)",
+        )
         parser.epilog = """
 examples/notes:
-  hf 14a raw -b 7 -d 40 -k
-  hf 14a raw -d 43 -k
-  hf 14a raw -d 3000 -c
-  hf 14a raw -sc -d 6000
+  hf 14a raw -b 7 40 -k
+  hf 14a raw 43 -k
+  hf 14a raw -c 3000
+  hf 14a raw -sc 6000
+  hf 14a raw -3sc 6000
 """
         return parser
 
@@ -7247,29 +7263,37 @@ examples/notes:
             "auto_select": self.bool_to_bit(args.select_tag),
             "keep_rf_field": self.bool_to_bit(args.keep_rf),
             "check_response_crc": self.bool_to_bit(args.crc_clear),
-            # 'auto_type3_select': self.bool_to_bit(args.type3-select-tag),
+            "no_rats": self.bool_to_bit(args.no_rats),
         }
-        data: str = args.data
-        if data is not None:
-            data = data.replace(" ", "")
-            if re.match(r"^[0-9a-fA-F]+$", data):
-                if len(data) % 2 != 0:
+
+        # Concatenate all positional hex args, stripping spaces
+        hex_str = "".join(args.data).replace(" ", "")
+        if hex_str:
+            if re.match(r"^[0-9a-fA-F]+$", hex_str):
+                if len(hex_str) % 2 != 0:
                     print(
                         f" [!] {color_string((CR, 'The length of the data must be an integer multiple of 2.'))}"
                     )
                     return
                 else:
-                    data_bytes = bytes.fromhex(data)
+                    data_bytes = bytes.fromhex(hex_str)
             else:
                 print(f" [!] {color_string((CR, 'The data must be a HEX string'))}")
                 return
         else:
             data_bytes = []
+
         if args.bits is not None and args.crc:
             print(
                 f" [!] {color_string((CR, '--bits and --crc are mutually exclusive'))}"
             )
             return
+
+        if args.verbose:
+            print(f" - options: {options}")
+            print(f" - timeout: {args.timeout} ms")
+            if data_bytes:
+                print(f" - data: {data_bytes.hex()}")
 
         # Exec 14a raw cmd.
         resp = self.cmd.hf14a_raw(options, args.timeout, data_bytes, args.bits)

--- a/software/script/chameleon_cmd.py
+++ b/software/script/chameleon_cmd.py
@@ -371,8 +371,7 @@ class ChameleonCMD:
 
         data = bytes(cs)+struct.pack(f'!HH{len(data)}s', resp_timeout_ms, bitlen, bytearray(data))
         resp = self.device.send_cmd_sync(Command.HF14A_RAW, data, timeout=(resp_timeout_ms // 1000) + 1)
-        resp.parsed = resp.data
-        return resp
+        return resp.data
 
     @expect_response(Status.HF_TAG_OK)
     def mf1_manipulate_value_block(self, src_block, src_type: MfcKeyType, src_key, operator: MfcValueBlockOperator, operand, dst_block, dst_type: MfcKeyType, dst_key):

--- a/software/script/chameleon_cmd.py
+++ b/software/script/chameleon_cmd.py
@@ -349,7 +349,8 @@ class ChameleonCMD:
                 ("auto_select", ctypes.c_uint8, 1),
                 ("keep_rf_field", ctypes.c_uint8, 1),
                 ("check_response_crc", ctypes.c_uint8, 1),
-                ("reserved", ctypes.c_uint8, 2),
+                ("no_rats", ctypes.c_uint8, 1),
+                ("reserved", ctypes.c_uint8, 1),
             ]
 
         cs = CStruct()
@@ -359,6 +360,7 @@ class ChameleonCMD:
         cs.auto_select = options['auto_select']
         cs.keep_rf_field = options['keep_rf_field']
         cs.check_response_crc = options['check_response_crc']
+        cs.no_rats = options.get('no_rats', 0)
 
         if bitlen is None:
             bitlen = len(data) * 8  # bits = bytes * 8(bit)


### PR DESCRIPTION
Make `hf 14a raw` take the same flags and positional args as pm3.

Changes:

- `-d <hex>` → positional `<hex> [<hex>...]`
  Before: `hf 14a raw -b 7 -d 40 -k`
  After:  `hf 14a raw -b 7 40 -k`

- Added `-3` / `--no-rats` — 14443-3 select, skip RATS
- Added `-v` / `--verbose`
- Firmware side gets a `no_rats` bit in the payload, temporarily switches
  `forcerats` config during card select