### PR TITLE
fix: hf14a_raw should return data bytes, not Response object

### DIFF
--- a/software/script/chameleon_cmd.py
+++ b/software/script/chameleon_cmd.py
@@ -371,8 +371,7 @@ class ChameleonCMD:
 
         data = bytes(cs)+struct.pack(f'!HH{len(data)}s', resp_timeout_ms, bitlen, bytearray(data))
         resp = self.device.send_cmd_sync(Command.HF14A_RAW, data, timeout=(resp_timeout_ms // 1000) + 1)
-        resp.parsed = resp.data
-        return resp
+        return resp.data
 
     @expect_response(Status.HF_TAG_OK)
     def mf1_manipulate_value_block(self, src_block, src_type: MfcKeyType, src_key, operator: MfcValueBlockOperator, operand, dst_block, dst_type: MfcKeyType, dst_key):


### PR DESCRIPTION
Callers treat the return value as bytes (len(), slicing), but hf14a_raw was returning the Response object itself, causing TypeError.

Before:

```
[USB] chameleon --> hf 14a raw -sc -d 3000
CLI exception: Traceback (most recent call last):
  File ".../chameleon_cli_main.py", line 146, in exec_cmd
    raise error
  File ".../chameleon_cli_main.py", line 141, in exec_cmd
    unit.on_exec(args_parse_result)
    ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^
  File ".../chameleon_cli_unit.py", line 7143, in on_exec
    if len(resp) > 0:
       ~~~^^^^^^
TypeError: object of type 'Response' has no len()
```

After:

```
[USB] chameleon --> hf 14a raw -sc -d 3000
 - 04
```