### PR TITLE
fix(lf): restore tank settling before field-loss sampling

### DIFF
--- a/firmware/application/src/rfid/nfctag/lf/lf_tag_em.c
+++ b/firmware/application/src/rfid/nfctag/lf/lf_tag_em.c
@@ -24,6 +24,7 @@
 NRF_LOG_MODULE_REGISTER();
 
 #define ANT_NO_MOD() nrf_gpio_pin_clear(LF_MOD)
+#define LF_125KHZ_BROADCAST_MAX (10)
 
 // Whether the USB light effect is allowed to enable
 extern bool g_usb_led_marquee_enable;
@@ -74,9 +75,6 @@ static void lpcomp_event_handler(nrf_lpcomp_event_t event) {
     }
 
     sleep_timer_stop();  // turn off dormant delay
-    // Disable LPCOMP during emulation — LF_RSSI fluctuates during load
-    // modulation and would trigger spurious DOWN events with DETECT_CROSS.
-    // Field-loss is checked periodically via EVT_END_SEQ0 in pwm_handler.
     nrfx_lpcomp_disable();
 
     // set the emulation status logo bit
@@ -89,9 +87,8 @@ static void lpcomp_event_handler(nrf_lpcomp_event_t event) {
     set_slot_light_color(RGB_BLUE);
     TAG_FIELD_LED_ON()
 
-    // Loop continuously — no stop/restart gaps between sequence plays.
-    // Field-loss is detected in pwm_handler via EVT_END_SEQ0.
-    nrfx_pwm_simple_playback(&m_broadcast, m_pwm_seq, 1, NRFX_PWM_FLAG_LOOP);
+    // use precise hardware timer to broadcast card id
+    nrfx_pwm_simple_playback(&m_broadcast, m_pwm_seq, LF_125KHZ_BROADCAST_MAX, NRFX_PWM_FLAG_STOP);
 
     NRF_LOG_INFO("LF FIELD DETECTED");
 }
@@ -108,23 +105,26 @@ static void lpcomp_init(void) {
 }
 
 static void pwm_handler(nrfx_pwm_evt_type_t event_type) {
-    if (event_type == NRFX_PWM_EVT_END_SEQ0) {
-        // Fired at end of each loop iteration — check field without stopping PWM.
-        // Mask UP interrupt while sampling to prevent re-entrancy.
-        NRF_LPCOMP->INTENCLR = LPCOMP_INTENCLR_UP_Msk;
-        if (!is_lf_field_exists()) {
-            // Field gone — stop the loop; pwm_handler will get EVT_STOPPED next.
-            nrfx_pwm_stop(&m_broadcast, false);
-        }
-        // Re-enable will happen either in lf_field_lost (via INTENSET) or stays
-        // suppressed while PWM keeps looping (we only need it after field_lost).
-        return;
-    }
     if (event_type != NRFX_PWM_EVT_STOPPED) {
         return;
     }
+
+    // After the last broadcast, force NO_MOD on antenna and wait for the
+    // envelope detector on LF_RSSI to discharge before sampling. The
+    // peak-detector RC at that node has a time constant of roughly 2 ms,
+    // so a 2 ms quiet window gives ~1 tau of decay, enough to drop the
+    // post-envelope voltage below the LPCOMP UP threshold when the reader
+    // is gone. Without this, residual modulation energy reads as
+    // "field present" and lf_field_lost() is never reached.
     ANT_NO_MOD();
-    lf_field_lost();
+    bsp_delay_ms(2);
+    NRF_LPCOMP->INTENCLR = LPCOMP_INTENCLR_CROSS_Msk | LPCOMP_INTENCLR_UP_Msk | LPCOMP_INTENCLR_DOWN_Msk | LPCOMP_INTENCLR_READY_Msk;
+    if (is_lf_field_exists()) {
+        nrfx_lpcomp_disable();
+        nrfx_pwm_simple_playback(&m_broadcast, m_pwm_seq, LF_125KHZ_BROADCAST_MAX, NRFX_PWM_FLAG_STOP);
+    } else {
+        lf_field_lost();
+    }
 }
 
 static void pwm_init(void) {


### PR DESCRIPTION
## Summary

PR #413 ("t55write" by @nieldk) bundled an undocumented rewrite of `firmware/application/src/rfid/nfctag/lf/lf_tag_em.c` (commit `f7feda5`) that broke field-loss detection during LF tag emulation. This PR is a focused, minimal revert of those chunks. The T5577 write functionality from #413 is untouched.

## Bug

After the device enters LF tag emulation and the reader is then removed, the white RF status LED stays on indefinitely, `g_is_tag_emulating` stays `true`, the LPCOMP UP interrupt is not re-armed, and the sleep timer never starts. The only way to clear the state is changing slot via the physical button, which calls `lf_sense_disable` explicitly. Reproduced on hw_v1, both USB-powered and on battery, with EM410X on slot 1.

This is more than cosmetic: `lf_field_lost()` is the only path that turns the LED off, re-arms LPCOMP for the next wake-up, and starts the low-power sleep timer. With the bug in place, the device permanently believes it is still in front of a reader.

## Root cause

The rewrite changed two things in the emulation control loop:

1. `nrfx_pwm_simple_playback` switched from a finite burst with `NRFX_PWM_FLAG_STOP` to a single sequence with `NRFX_PWM_FLAG_LOOP`, i.e. forever-looping playback.
2. The field check moved from the `NRFX_PWM_EVT_STOPPED` handler to `NRFX_PWM_EVT_END_SEQ0`, with no antenna release and no settling delay.

The combination is incompatible with how field detection works on this hardware. `LF_RSSI` is the output of a peak detector with an RC time constant of roughly 2 ms (independently characterized by reviewers in the #413 discussion, one of them while attempting to detect 48 us BPLM gaps for HITAG). While the PWM is actively load-modulating, that node keeps reading the local drive, so LPCOMP returns "field present" regardless of whether the reader is still there. `is_lf_field_exists()` returns `true` forever and `lf_field_lost()` is never reached.

## Why a delay inside `EVT_END_SEQ0` does not fix it

Adding `ANT_NO_MOD()` plus a settling delay inside the loop event handler does not work. With `NRFX_PWM_FLAG_LOOP`, the PWM peripheral keeps writing `LF_MOD` autonomously, so clearing the pin in software is overwritten within microseconds and the post-envelope voltage never gets a chance to discharge. The delay value does not matter, the pin is never quiet during it. Confirmed on hardware.

You cannot sample `LF_RSSI` while load modulation is active. The PWM has to actually stop, the antenna has to be released, and the envelope detector needs about one time constant (~2 ms) to discharge before the sample is meaningful.

## Fix

Partial revert of the relevant chunks of `lf_tag_em.c`:

* Playback restored to `(LF_125KHZ_BROADCAST_MAX, NRFX_PWM_FLAG_STOP)`, i.e. 10 bursts then stop.
* Field check restored to `NRFX_PWM_EVT_STOPPED`, with `ANT_NO_MOD()`, `bsp_delay_ms(2)`, an LPCOMP int clear, and the re-check that either restarts the next 10-burst block or calls `lf_field_lost()`.

The 2 ms quiet window matches the LF_RSSI peak-detector time constant, giving one tau of decay (~63 percent), enough to drop the post-envelope voltage below the LPCOMP UP threshold once the reader is gone. The trade-off is a 2 ms gap every ~10 sequence plays, which is well within tolerance for the LF readers we tested.

A shorter 1 ms delay was also verified working on hardware in the same scenario, so this PR is conservative on the safe side. 2 ms is chosen to align with the independently characterized RC time constant of the peak detector and to leave margin across hardware variants.

The rest of the logic is identical to the code that ran unchanged from `a421e99` (March 2026) up to the merge of #413 (May 8, 2026).

## Alternatives considered

These would preserve the `FLAG_LOOP` intent but were rejected as more invasive than the revert with no measurable benefit on tested readers:

1. **TIMER plus PPI to pause and resume the PWM around the sample**: keeps the loop, adds another peripheral to the state machine and roughly 50 to 100 lines of glue code.
2. **Silent tail appended to every protocol's wave form**: a few PWM entries with no modulation at the end of each sequence, used as the sampling window. Touches every LF modulator (em410x, hidprox, ioprox, viking, pac).

If a timing-sensitive reader use case shows up later, either can become a separate `perf(lf): gapless emulation` follow-up with its own justification.

## Test plan

Verified on hardware (Chameleon Ultra hw_v1):

* `origin/main` after #413: LED stuck, reproduces the report.
* Pre-#413 logic: LED turns off promptly when reader is removed. Baseline.
* This branch: LED turns off promptly when reader is removed, EM410X emulation on slot 1 still accepted by the same reader, no other behaviour change observed.