### PR TITLE
fix(cli): support non-interactive help and gated hardware test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project uses the changelog in accordance with [keepchangelog](http://keepachangelog.com/). Please use this to write notable changes, which is not the same as git commit log...
 
 ## [unreleased][unreleased]
+ - Fix CLI non-interactive help and add one-shot `--command` flag; gate hardware acquisition test on `CHAMELEON_PORT` env var (@melxusgid)
  - Added IDTECK LF protocol support: tag emulation (PSK1 RF/32) and T55xx clone. No reader path yet; PSK demodulation on the envelope-only receive chain is left for a follow-up.
  - Added PAC/Stanley LF protocol support: read, emulate and T55xx clone (@kevihiiin, @danieltwagner)
  - Fix firmware application USB serial number (@taichunmin)

--- a/software/script/chameleon_cli_main.py
+++ b/software/script/chameleon_cli_main.py
@@ -12,6 +12,10 @@ from prompt_toolkit.formatted_text import ANSI
 from prompt_toolkit.history import FileHistory
 from chameleon_utils import CR, CG, CY, color_string
 
+
+EXIT_SUCCESS = 0
+EXIT_NONINTERACTIVE = 2
+
 ULTRA = r"""
                                                                 ╦ ╦╦ ╔╦╗╦═╗╔═╗
                                                    ███████      ║ ║║  ║ ╠╦╝╠═╣
@@ -181,9 +185,47 @@ class ChameleonCLI:
             self.exec_cmd(cmd_str)
 
 
-if __name__ == '__main__':
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Chameleon Ultra CLI")
+    parser.add_argument(
+        "-c",
+        "--command",
+        action="append",
+        help="execute one CLI command and exit; may be passed more than once",
+    )
+    return parser
+
+
+def main(argv=None) -> int:
     if sys.version_info < (3, 9):
         raise Exception("This script requires at least Python 3.9")
+
+    parser = build_arg_parser()
+    args = parser.parse_args(argv)
+
     colorama.init(autoreset=True)
     chameleon_cli_unit.check_tools()
-    ChameleonCLI().startCLI()
+
+    cli = ChameleonCLI()
+    if args.command:
+        for command in args.command:
+            try:
+                cli.exec_cmd(command)
+            except SystemExit as e:
+                # The interactive "exit" command uses a non-zero sentinel to
+                # break the prompt loop. Treat it as success for one-shot use.
+                if e.code == 996:
+                    return EXIT_SUCCESS
+                raise
+        return EXIT_SUCCESS
+
+    if not sys.stdin.isatty():
+        parser.error("an interactive terminal is required unless --command is used")
+        return EXIT_NONINTERACTIVE
+
+    cli.startCLI()
+    return EXIT_SUCCESS
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/software/script/tests/test_cli_entrypoint.py
+++ b/software/script/tests/test_cli_entrypoint.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+SCRIPT_DIR = Path(__file__).resolve().parents[1]
+CLI_MAIN = SCRIPT_DIR / "chameleon_cli_main.py"
+
+
+def run_cli(*args, stdin=""):
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(SCRIPT_DIR)
+    return subprocess.run(
+        [sys.executable, str(CLI_MAIN), *args],
+        input=stdin,
+        text=True,
+        capture_output=True,
+        timeout=5,
+        env=env,
+    )
+
+
+def test_help_exits_without_starting_interactive_prompt():
+    result = run_cli("--help")
+
+    assert result.returncode == 0
+    assert "usage:" in result.stdout
+    assert "Chameleon Ultra CLI" in result.stdout
+    assert "prompt_toolkit" not in result.stderr
+
+
+def test_non_interactive_without_command_fails_cleanly():
+    result = run_cli()
+
+    assert result.returncode != 0
+    assert "interactive terminal" in result.stderr
+    assert "prompt_toolkit" not in result.stderr

--- a/software/script/tests/test_hard_acquire.py
+++ b/software/script/tests/test_hard_acquire.py
@@ -1,9 +1,20 @@
 #!/usr/bin/env python3
+import os
+import sys
+import unittest
+
+sys.path.append('..')
+
 import hardnested_utils
 from chameleon_cmd import ChameleonCMD
-from chameleon_com import ChameleonCom, OpenFailException
-import sys
-sys.path.append('..')
+from chameleon_com import ChameleonCom
+
+
+def open_test_device():
+    port = os.environ.get("CHAMELEON_PORT")
+    if not port:
+        raise unittest.SkipTest("set CHAMELEON_PORT to run hardware tests")
+    return ChameleonCom().open(port)
 
 
 def test_hardnested_acquire():
@@ -24,10 +35,7 @@ def test_hardnested_acquire():
     #   (4byte uid of card) - (block_target 1byte) - (type_target 1byte) - (nonces from device Nbytes)
 
     # ------------------------     open the device     ------------------------
-    try:
-        cml = ChameleonCom().open('com19')
-    except OpenFailException:
-        cml = ChameleonCom().open('/dev/ttyACM0')
+    cml = open_test_device()
     cml_cmd = ChameleonCMD(cml)
 
     # ------------------------ SET DEVICE MODE ------------------------


### PR DESCRIPTION
### Summary

This PR makes two small CLI/test hygiene improvements:

- Adds a real `argparse` entrypoint for `chameleon_cli_main.py`, so `--help` works without starting the interactive `prompt_toolkit` prompt.
- Makes the hardnested hardware acquisition test opt-in via `CHAMELEON_PORT` instead of hardcoding `com19` and `/dev/ttyACM0`.

It also adds a small one-shot command mode:

```bash
python script/chameleon_cli_main.py --command "rem hello"
```

### Why

Before this change, running CLI help from a non-interactive environment could enter the interactive prompt path instead of printing help cleanly. This is inconvenient for scripts, CI, and automation.

The hardnested acquisition test also failed on machines where the device is not available at `com19` or `/dev/ttyACM0`. On macOS, for example, Chameleon Ultra commonly appears as a `/dev/cu.usbmodem...` device.

With this change, hardware tests only run when a port is explicitly provided:

```bash
CHAMELEON_PORT=/dev/cu.usbmodem0000000000001 pytest script/tests/test_hard_acquire.py
```

If `CHAMELEON_PORT` is not set, the test is skipped instead of failing due to a missing hardcoded port.

### Test plan

Ran from `software/` against a plugged-in Chameleon Ultra on macOS:

```text
test_help_exits_without_starting_interactive_prompt        PASSED
test_non_interactive_without_command_fails_cleanly         PASSED
test_hardnested_acquire                                    FAILED (expected — no HF tag placed on reader)
test_crypto1::test_key_getter_setter                       PASSED
test_crypto1::test_mfkey32_is_reader_has_key_false         PASSED
test_crypto1::test_mfkey32_is_reader_has_key_true          PASSED
test_crypto1::test_prng_next                               PASSED
test_crypto1::test_reader_three_pass_auth                  PASSED
test_crypto1::test_tag_three_pass_auth                     PASSED

8 passed, 1 failed
```

The hardware test failure is expected — `HF tag no found or lost` means the device connected and tried to scan, but no Mifare Classic tag was physically present on the reader.

Also verified manually:

```bash
PYTHONPATH=script python script/chameleon_cli_main.py --help
PYTHONPATH=script python script/chameleon_cli_main.py --command "rem hello from automation"
PYTHONPATH=script python script/chameleon_cli_main.py </dev/null
```

Expected behavior:

- `--help` prints usage and exits 0.
- `--command` executes a one-shot CLI command and exits 0.
- no args in a non-interactive terminal exits with a clear argparse error instead of entering `prompt_toolkit`.

### Notes

This PR intentionally avoids changing RFID behavior. It only improves automation ergonomics and test portability.