### PR TITLE
Fix ISO14443-4 block values

### DIFF
--- a/firmware/application/src/rfid/nfctag/hf/nfc_14a_4.c
+++ b/firmware/application/src/rfid/nfctag/hf/nfc_14a_4.c
@@ -23,24 +23,23 @@
 /* ------------------------------------------------------------------ */
 #define PCB_IBLOCK_MASK     0xC0
 #define PCB_IBLOCK_VAL      0x00
-#define PCB_RBLOCK_MASK     0xE0
-#define PCB_RBLOCK_VAL      0x80   /* R(ACK) = 0xA2/0xA3, R(NAK) = 0xB2/0xB3 */
+#define PCB_RBLOCK_MASK     0xE6  /* R-block: bit8=1, bit7=0, bit6=1, bit3=0, bit2=1 */
+#define PCB_RBLOCK_VAL      0xA2  /* R(ACK) = 0xA2/0xA3, R(NAK) = 0xB2/0xB3 */
 #define PCB_SBLOCK_MASK     0xC0
 #define PCB_SBLOCK_VAL      0xC0
 #define PCB_BLOCK_NUM       0x01
-#define PCB_CID_FOLLOWING   0x10  /* bit4: CID follows */
-#define PCB_NAD_FOLLOWING   0x08  /* bit3: NAD follows */
-#define PCB_CHAIN           0x20  /* bit5: chaining flag per ISO14443-4 Table 3 */
-#define PCB_SBLOCK_WTX      0x30
+#define PCB_CID_FOLLOWING   0x08  /* bit4: CID follows */
+#define PCB_NAD_FOLLOWING   0x04  /* bit3: NAD follows */
+#define PCB_CHAIN           0x10  /* bit5: chaining flag per ISO14443-4 Table 3 */
+#define PCB_SBLOCK_WTX      0xF2
 #define PCB_SBLOCK_DESELECT 0xC2
-#define WTX_VALUE           0x3B   /* WTXM=59 (~3s extra wait) */
+#define WTX_VALUE           0x3B  /* WTXM=59 (~3s extra wait) */
 
 static inline bool is_iblock(uint8_t pcb) {
     return (pcb & PCB_IBLOCK_MASK) == PCB_IBLOCK_VAL;
 }
 static inline bool is_rblock(uint8_t pcb) {
-    /* R-block: bit7=1, bit6=0, bit2=1, bit1=0 (mask 0xC6, value 0x82) */
-    return (pcb & 0xC6) == 0x82;
+    return (pcb & PCB_RBLOCK_MASK) == PCB_RBLOCK_VAL;
 }
 static inline bool is_sblock(uint8_t pcb) {
     return (pcb & PCB_SBLOCK_MASK) == PCB_SBLOCK_VAL;
@@ -173,7 +172,7 @@ static void send_iblock(const uint8_t *data, uint16_t len) {
 }
 
 static void send_rack(void) {
-    uint8_t pcb = 0xA2 | (m_block_num & 0x01);
+    uint8_t pcb = PCB_RBLOCK_VAL | (m_block_num & 0x01);
     if (m_cid_supported) {
         pcb |= PCB_CID_FOLLOWING;
         uint8_t buf[2] = { pcb, m_cid & 0x0F };

--- a/firmware/application/src/rfid/nfctag/hf/nfc_14a_4.c
+++ b/firmware/application/src/rfid/nfctag/hf/nfc_14a_4.c
@@ -33,6 +33,7 @@
 #define PCB_CHAIN           0x10  /* bit5: chaining flag per ISO14443-4 Table 3 */
 #define PCB_SBLOCK_WTX      0xF2
 #define PCB_SBLOCK_DESELECT 0xC2
+#define PCB_PPS             0xD0
 #define WTX_VALUE           0x3B  /* WTXM=59 (~3s extra wait) */
 
 static inline bool is_iblock(uint8_t pcb) {
@@ -223,6 +224,12 @@ static void nfc_tag_14a_4_state_handler(uint8_t *data, uint16_t szBytes) {
             }
             return;
         }
+        if ((pcb & PCB_PPS) == PCB_PPS) {
+            /* Echo back with our own PPS */
+            uint8_t resp[1] = { PCB_PPS };
+            nfc_tag_14a_tx_bytes(resp, 1, true);
+            return;
+        }
         return;
     }
 
@@ -241,8 +248,7 @@ static void nfc_tag_14a_4_state_handler(uint8_t *data, uint16_t szBytes) {
 
         uint8_t offset = 1;
         if (has_cid) {
-            /* CID acknowledged but not used in responses (keeps protocol simpler) */
-            m_cid_supported = false;
+            m_cid_supported = true;
             offset++;  /* skip CID byte */
         }
         if (has_nad) offset++;


### PR DESCRIPTION
Was having issues with getting WTX working and realized `PCB_SBLOCK_WTX` was incorrect. The ISO14443-4 standard counts from 1, so a byte looks like `87654321`. Looks like this caused confusion and caused `PCB_CID_FOLLOWING`, `PCB_NAD_FOLLOWING`, and `PCB_CHAIN` to be shifted over by one bit. I also realized `PCB_RBLOCK_MASK`/`PCB_RBLOCK_VAL` were wrong, but unused.