### PR TITLE
feat(lf): DC-block FSK demod for weak-coupling robustness (HID, ioProx)

### DIFF
--- a/firmware/application/src/rfid/nfctag/lf/protocols/hidprox.c
+++ b/firmware/application/src/rfid/nfctag/lf/protocols/hidprox.c
@@ -50,6 +50,12 @@ hidprox_codec *hidprox_codec_alloc(void) {
     hidprox_codec *d = malloc(sizeof(hidprox_codec));
     d->card = NULL;
     d->modem = fsk_alloc(FSK_BITRATE_HID);
+    if (d->modem) {
+        // Subtract a running DC baseline before the Goertzel. The raw ADC DC
+        // offset biases the fc/8 bin and, on weakly-coupled cards, pins every
+        // bit to 0 so nothing decodes. This extends the usable coupling range.
+        d->modem->dc_block = true;
+    }
     return d;
 }
 

--- a/firmware/application/src/rfid/nfctag/lf/protocols/ioprox.c
+++ b/firmware/application/src/rfid/nfctag/lf/protocols/ioprox.c
@@ -278,6 +278,11 @@ static void *ioprox_codec_alloc(void) {
     if (!d) return NULL;
     memset(d, 0, sizeof(*d));
     d->modem = fsk_alloc(FSK_BITRATE_IOPROX);
+    if (d->modem) {
+        // Subtract a running DC baseline before the Goertzel (weak-coupling
+        // robustness; see hidprox_codec_alloc). Same FSK demod path.
+        d->modem->dc_block = true;
+    }
     return d;
 }
 

--- a/firmware/application/src/rfid/nfctag/lf/utils/fskdemod.c
+++ b/firmware/application/src/rfid/nfctag/lf/utils/fskdemod.c
@@ -7,7 +7,7 @@
 #define PI 3.14159265358979f
 #define GOERTZEL(FREQ, SAMPLE_RATE) (2.0 * cos((2.0 * PI * FREQ) / (SAMPLE_RATE)))
 
-float goertzel_mag(float coef, uint16_t samples[], int n) {
+static float goertzel_power(float coef, const uint16_t samples[], int n) {
     float z1 = 0;
     float z2 = 0;
     for (int i = 0; i < n; i++) {
@@ -15,7 +15,11 @@ float goertzel_mag(float coef, uint16_t samples[], int n) {
         z2 = z1;
         z1 = z0;
     }
-    return sqrt(z1 * z1 + z2 * z2 - coef * z1 * z2);
+    // Squared magnitude (|X|^2). The bit decision only compares two of these,
+    // and power is monotonic with magnitude, so the sqrt is dropped entirely.
+    // Result can be slightly negative from rounding; harmless for a comparison
+    // (and avoids the sqrt(NaN) the old magnitude version could hit near zero).
+    return z1 * z1 + z2 * z2 - coef * z1 * z2;
 }
 
 void fsk_free(fsk_t *m) {
@@ -33,8 +37,8 @@ bool fsk_feed(fsk_t *m, uint16_t sample, bool *bit) {
     if (m->c < m->bitrate) {
         return false;
     }
-    float bit0 = goertzel_mag(m->goertzel_fc_8,  m->samples, m->bitrate);
-    float bit1 = goertzel_mag(m->goertzel_fc_10, m->samples, m->bitrate);
+    float bit0 = goertzel_power(m->goertzel_fc_8,  m->samples, m->bitrate);
+    float bit1 = goertzel_power(m->goertzel_fc_10, m->samples, m->bitrate);
     *bit = (bit1 > bit0);
 
     // Reset counter and clear sample buffer for the next bit

--- a/firmware/application/src/rfid/nfctag/lf/utils/fskdemod.c
+++ b/firmware/application/src/rfid/nfctag/lf/utils/fskdemod.c
@@ -7,18 +7,26 @@
 #define PI 3.14159265358979f
 #define GOERTZEL(FREQ, SAMPLE_RATE) (2.0 * cos((2.0 * PI * FREQ) / (SAMPLE_RATE)))
 
-static float goertzel_power(float coef, const uint16_t samples[], int n) {
+// Goertzel squared magnitude (|X|^2) with an optional DC offset subtracted from
+// each sample.
+//
+// No sqrt: the bit decision only compares two of these and power is monotonic
+// with magnitude, so the sqrt is dropped (the Cortex-M4F FPU has no double
+// hardware; a double sqrt() would pull in a soft-float routine). The result can
+// round slightly negative near zero signal, which is harmless for a comparison.
+//
+// DC offset: a 50-sample (RF/50) window holds an integer number of fc/10 cycles
+// but a non-integer count of fc/8, so the raw ADC's DC component leaks into the
+// fc/8 bin and biases the decision toward fc/8. Subtracting a running baseline
+// (dc) removes that bias; pass dc=0 for the legacy behaviour.
+static float goertzel_power(float coef, const uint16_t samples[], int n, float dc) {
     float z1 = 0;
     float z2 = 0;
     for (int i = 0; i < n; i++) {
-        float z0 = coef * z1 - z2 + (float)(samples[i]);
+        float z0 = coef * z1 - z2 + ((float)samples[i] - dc);
         z2 = z1;
         z1 = z0;
     }
-    // Squared magnitude (|X|^2). The bit decision only compares two of these,
-    // and power is monotonic with magnitude, so the sqrt is dropped entirely.
-    // Result can be slightly negative from rounding; harmless for a comparison
-    // (and avoids the sqrt(NaN) the old magnitude version could hit near zero).
     return z1 * z1 + z2 * z2 - coef * z1 * z2;
 }
 
@@ -33,12 +41,25 @@ void fsk_free(fsk_t *m) {
  * multiple protocols with different speeds.
  */
 bool fsk_feed(fsk_t *m, uint16_t sample, bool *bit) {
+    if (m->dc_block) {
+        // Slow IIR baseline tracker (time const ~64 samples). Removes the large
+        // raw-ADC DC offset that otherwise leaks into the fc/8 Goertzel bin and
+        // pins every decision to bit 0. Unlike a per-window mean, a running
+        // baseline does not distort fc/8's non-integer cycle count in a window.
+        if (!m->dc_seen) {
+            m->dc_run = (float)sample;
+            m->dc_seen = true;
+        } else {
+            m->dc_run += ((float)sample - m->dc_run) * (1.0f / 64.0f);
+        }
+    }
     m->samples[m->c++] = sample;
     if (m->c < m->bitrate) {
         return false;
     }
-    float bit0 = goertzel_power(m->goertzel_fc_8,  m->samples, m->bitrate);
-    float bit1 = goertzel_power(m->goertzel_fc_10, m->samples, m->bitrate);
+    float dc = m->dc_block ? m->dc_run : 0.0f;
+    float bit0 = goertzel_power(m->goertzel_fc_8,  m->samples, m->bitrate, dc);
+    float bit1 = goertzel_power(m->goertzel_fc_10, m->samples, m->bitrate, dc);
     *bit = (bit1 > bit0);
 
     // Reset counter and clear sample buffer for the next bit
@@ -61,6 +82,9 @@ fsk_t *fsk_alloc(uint8_t bitrate) {
 
     m->bitrate = bitrate;
     m->c = 0;
+    m->dc_block = false;
+    m->dc_seen = false;
+    m->dc_run = 0.0f;
     m->goertzel_fc_8 = GOERTZEL(15625.0f, 125000.0f);
     m->goertzel_fc_10 = GOERTZEL(12500.0f, 125000.0f);
     return m;

--- a/firmware/application/src/rfid/nfctag/lf/utils/fskdemod.h
+++ b/firmware/application/src/rfid/nfctag/lf/utils/fskdemod.h
@@ -14,6 +14,9 @@ extern "C" {
 typedef struct {
     uint8_t bitrate; // 50 or 64
     uint8_t c;
+    bool dc_block;   // subtract a running DC baseline before Goertzel (off by default)
+    bool dc_seen;    // running-baseline initialised
+    float dc_run;    // IIR-tracked DC baseline
     uint16_t samples[FSK_MAX_BITRATE];
     float goertzel_fc_8;
     float goertzel_fc_10;


### PR DESCRIPTION
Found out about this while working with Claude on adding my Pyramid tag #453 - the reality is that the tag does not read that well on CU and this was the deciding step to get the data demodulated properly for that type of FSK. 

---
Claude:

The FSK demod (fsk_feed) ran the Goertzel tone detection directly on the raw ADC samples. Their large DC offset leaks into the fc/8 bin and biases every decision toward bit 0; on a weakly-coupled card the AC signal is too small to overcome it, so the whole bitstream collapses to zeros and nothing decodes. Strong signals overrode the bias, which is why this went unnoticed.

Adds an opt-in running DC baseline tracker to the demod (fsk_t.dc_block): a slow per-sample IIR estimate (~64-sample time constant) subtracted before the Goertzel. Unlike a per-window mean it doesn't distort fc/8's non-integer cycle count. Enabled for the HID Prox and ioProx modems.

Validated on hardware (HID H10301, FC 12 / CN 3456 on a T55xx clone):
  - well coupled  (std 25): stock reads;        with fix 5/5
  - weak coupled  (std 15): stock fails 4/4;     with fix 4/5 correct
  - very weak     (std 11): stock fails;         with fix reads (occasional
    misread — HID 26-bit has only parity, no CRC, so marginal bit errors can
    pass; this is an HID format limitation, not introduced here)
ioProx uses the identical demod path; enabled by analogy (no card to test).