### PR TITLE
Add Farpointe Pyramid emulation and reading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project uses the changelog in accordance with [keepchangelog](http://keepachangelog.com/). Please use this to write notable changes, which is not the same as git commit log...
 
 ## [unreleased][unreleased]
+ - Added Farpointe/Pyramid LF protocol support: read and emulate (FSK2a, RF/50)
  - Added Jablotron LF protocol support: read, emulate and T55xx clone (@midlan)
  - Added IDTECK LF protocol support: tag emulation (PSK1 RF/32) and T55xx clone. No reader path yet; PSK demodulation on the envelope-only receive chain is left for a follow-up.
  - Added PAC/Stanley LF protocol support: read, emulate and T55xx clone (@kevihiiin, @danieltwagner)

--- a/firmware/application/Makefile
+++ b/firmware/application/Makefile
@@ -45,6 +45,7 @@ SRC_FILES += \
   $(PROJ_DIR)/rfid/nfctag/lf/utils/diphase.c \
   $(PROJ_DIR)/rfid/nfctag/lf/protocols/wiegand.c \
   $(PROJ_DIR)/rfid/nfctag/lf/protocols/idteck.c \
+  $(PROJ_DIR)/rfid/nfctag/lf/protocols/pyramid.c \
   $(PROJ_DIR)/utils/dataframe.c \
   $(PROJ_DIR)/utils/delayed_reset.c \
   $(PROJ_DIR)/utils/fds_util.c \
@@ -358,6 +359,7 @@ ifeq	(${CURRENT_DEVICE_TYPE}, ${CHAMELEON_ULTRA})
     $(PROJ_DIR)/rfid/reader/lf/lf_ioprox_data.c \
     $(PROJ_DIR)/rfid/reader/lf/lf_viking_data.c \
     $(PROJ_DIR)/rfid/reader/lf/lf_jablotron_data.c \
+    $(PROJ_DIR)/rfid/reader/lf/lf_pyramid_data.c \
 
   INC_FOLDERS +=\
     ${PROJ_DIR}/rfid/reader/ \

--- a/firmware/application/src/app_cmd.c
+++ b/firmware/application/src/app_cmd.c
@@ -880,6 +880,15 @@ static data_frame_tx_t *cmd_processor_jablotron_scan(uint16_t cmd, uint16_t stat
     return data_frame_make(cmd, STATUS_LF_TAG_OK, sizeof(card_buffer), card_buffer);
 }
 
+static data_frame_tx_t *cmd_processor_pyramid_scan(uint16_t cmd, uint16_t status, uint16_t length, uint8_t *data) {
+    uint8_t card_data[16] = {0};  // raw 128-bit Pyramid frame
+    status = scan_pyramid(card_data);
+    if (status != STATUS_LF_TAG_OK) {
+        return data_frame_make(cmd, status, 0, NULL);
+    }
+    return data_frame_make(cmd, STATUS_LF_TAG_OK, sizeof(card_data), card_data);
+}
+
 static data_frame_tx_t *cmd_processor_jablotron_write_to_t55xx(uint16_t cmd, uint16_t status, uint16_t length, uint8_t *data) {
     typedef struct {
         uint8_t id[5];
@@ -2502,14 +2511,12 @@ static data_frame_tx_t *cmd_processor_hf14a_4_reader_apdu(uint16_t cmd, uint16_t
     }
 
     /* Copy data portion (strip PCB + CRC), then handle chaining */
-    uint8_t blk_num = 0;
     uint8_t resp_pcb = resp_buf[0];
     uint8_t dlen = resp_bytes - 3; /* subtract PCB(1) + CRC(2) */
     if (dlen > 0 && resp_chain_len + dlen < sizeof(resp_chain)) {
         memcpy(&resp_chain[resp_chain_len], &resp_buf[1], dlen);
         resp_chain_len += dlen;
     }
-    blk_num ^= 1;
 
     /* ISO14443-4 chaining: PCB bit5 (0x20) set means more blocks follow */
     while (resp_pcb & 0x20) {
@@ -2532,7 +2539,6 @@ static data_frame_tx_t *cmd_processor_hf14a_4_reader_apdu(uint16_t cmd, uint16_t
             memcpy(&resp_chain[resp_chain_len], &resp_buf[1], dlen);
             resp_chain_len += dlen;
         }
-        blk_num ^= 1;
     }
 
     return data_frame_make(cmd, STATUS_HF_TAG_OK, resp_chain_len, resp_chain);
@@ -3045,6 +3051,7 @@ static cmd_data_map_t m_data_cmd_map[] = {
     {    DATA_CMD_PAC_WRITE_TO_T55XX,           before_reader_run,           cmd_processor_pac_write_to_t55xx,            NULL                   },
     {    DATA_CMD_JABLOTRON_SCAN,               before_reader_run,           cmd_processor_jablotron_scan,                NULL                   },
     {    DATA_CMD_JABLOTRON_WRITE_TO_T55XX,     before_reader_run,           cmd_processor_jablotron_write_to_t55xx,      NULL                   },
+    {    DATA_CMD_PYRAMID_SCAN,                 before_reader_run,           cmd_processor_pyramid_scan,                  NULL                   },
     {    DATA_CMD_IDTECK_WRITE_TO_T55XX,        before_reader_run,           cmd_processor_idteck_write_to_t55xx,         NULL                   },
     {    DATA_CMD_LF_T55XX_WRITE,               before_reader_run,           cmd_processor_lf_t55xx_write,                NULL                   },
     {    DATA_CMD_ADC_GENERIC_READ,             before_reader_run,           cmd_processor_generic_read,                  NULL                   },

--- a/firmware/application/src/data_cmd.h
+++ b/firmware/application/src/data_cmd.h
@@ -113,6 +113,7 @@
 #define DATA_CMD_IDTECK_WRITE_TO_T55XX          (3018)
 #define DATA_CMD_JABLOTRON_SCAN                 (3019)
 #define DATA_CMD_JABLOTRON_WRITE_TO_T55XX       (3020)
+#define DATA_CMD_PYRAMID_SCAN                   (3021)
 
 //
 // ******************************************************************

--- a/firmware/application/src/rfid/nfctag/lf/lf_tag_em.c
+++ b/firmware/application/src/rfid/nfctag/lf/lf_tag_em.c
@@ -14,6 +14,7 @@
 #include "protocols/ioprox.h"
 #include "protocols/jablotron.h"
 #include "protocols/pac.h"
+#include "protocols/pyramid.h"
 #include "protocols/viking.h"
 #include "syssleep.h"
 #include "tag_emulation.h"
@@ -288,6 +289,15 @@ int lf_tag_data_loadcb(tag_specific_type_t type, tag_data_buffer_t *buffer) {
         return LF_IDTECK_TAG_ID_SIZE;
     }
 
+    if (type == TAG_TYPE_FARPOINTE_PYRAMID && buffer->length >= LF_PYRAMID_TAG_ID_SIZE) {
+        m_tag_type = type;
+        void *codec = pyramid.alloc();
+        m_pwm_seq = pyramid.modulator(codec, buffer->buffer);
+        pyramid.free(codec);
+        NRF_LOG_INFO("load lf pyramid data finish.");
+        return LF_PYRAMID_TAG_ID_SIZE;
+    }
+
     NRF_LOG_ERROR("no valid data exists in buffer for tag type: %d.", type);
     return 0;
 }
@@ -442,6 +452,21 @@ bool lf_tag_idteck_data_factory(uint8_t slot, tag_specific_type_t tag_type) {
     uint8_t tag_id[LF_IDTECK_TAG_ID_SIZE] = {
         0x49, 0x44, 0x54, 0x4B,   // "IDTK" preamble (MSB first)
         0xDE, 0xAD, 0xBE, 0xEF,   // default card data
+    };
+    return lf_tag_data_factory(slot, tag_type, tag_id, sizeof(tag_id));
+}
+
+/** @brief Pyramid data save callback. */
+int lf_tag_pyramid_data_savecb(tag_specific_type_t type, tag_data_buffer_t *buffer) {
+    return m_tag_type == TAG_TYPE_FARPOINTE_PYRAMID ? LF_PYRAMID_TAG_ID_SIZE : 0;
+}
+
+/** @brief Pyramid default frame: full 128-bit on-air frame, replayed verbatim. */
+bool lf_tag_pyramid_data_factory(uint8_t slot, tag_specific_type_t tag_type) {
+    // A valid 26-bit Pyramid frame (preamble + Wiegand + parity + CRC-8/Maxim).
+    uint8_t tag_id[LF_PYRAMID_TAG_ID_SIZE] = {
+        0x00, 0x01, 0x01, 0x4A, 0x3E, 0x01, 0x01, 0x01,
+        0x01, 0x01, 0x01, 0x4A, 0xE3, 0x5E, 0x7F, 0x4F,
     };
     return lf_tag_data_factory(slot, tag_type, tag_id, sizeof(tag_id));
 }

--- a/firmware/application/src/rfid/nfctag/lf/lf_tag_em.h
+++ b/firmware/application/src/rfid/nfctag/lf/lf_tag_em.h
@@ -13,6 +13,7 @@
 #define LF_PAC_TAG_ID_SIZE 8
 #define LF_JABLOTRON_TAG_ID_SIZE 5
 #define LF_IDTECK_TAG_ID_SIZE 8
+#define LF_PYRAMID_TAG_ID_SIZE 16
 
 void lf_tag_125khz_sense_switch(bool enable);
 int lf_tag_data_loadcb(tag_specific_type_t type, tag_data_buffer_t *buffer);
@@ -30,4 +31,6 @@ int lf_tag_jablotron_data_savecb(tag_specific_type_t type, tag_data_buffer_t *bu
 bool lf_tag_jablotron_data_factory(uint8_t slot, tag_specific_type_t tag_type);
 int lf_tag_idteck_data_savecb(tag_specific_type_t type, tag_data_buffer_t *buffer);
 bool lf_tag_idteck_data_factory(uint8_t slot, tag_specific_type_t tag_type);
+int lf_tag_pyramid_data_savecb(tag_specific_type_t type, tag_data_buffer_t *buffer);
+bool lf_tag_pyramid_data_factory(uint8_t slot, tag_specific_type_t tag_type);
 bool is_lf_field_exists(void);

--- a/firmware/application/src/rfid/nfctag/lf/protocols/hidprox.c
+++ b/firmware/application/src/rfid/nfctag/lf/protocols/hidprox.c
@@ -50,6 +50,12 @@ hidprox_codec *hidprox_codec_alloc(void) {
     hidprox_codec *d = malloc(sizeof(hidprox_codec));
     d->card = NULL;
     d->modem = fsk_alloc(FSK_BITRATE_HID);
+    if (d->modem) {
+        // Subtract a running DC baseline before the Goertzel. The raw ADC DC
+        // offset biases the fc/8 bin and, on weakly-coupled cards, pins every
+        // bit to 0 so nothing decodes. This extends the usable coupling range.
+        d->modem->dc_block = true;
+    }
     return d;
 }
 

--- a/firmware/application/src/rfid/nfctag/lf/protocols/ioprox.c
+++ b/firmware/application/src/rfid/nfctag/lf/protocols/ioprox.c
@@ -278,6 +278,11 @@ static void *ioprox_codec_alloc(void) {
     if (!d) return NULL;
     memset(d, 0, sizeof(*d));
     d->modem = fsk_alloc(FSK_BITRATE_IOPROX);
+    if (d->modem) {
+        // Subtract a running DC baseline before the Goertzel (weak-coupling
+        // robustness; see hidprox_codec_alloc). Same FSK demod path.
+        d->modem->dc_block = true;
+    }
     return d;
 }
 

--- a/firmware/application/src/rfid/nfctag/lf/protocols/pyramid.c
+++ b/firmware/application/src/rfid/nfctag/lf/protocols/pyramid.c
@@ -1,0 +1,232 @@
+#include "pyramid.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+#include "nrf_pwm.h"
+#include "tag_base_type.h"
+
+// FSK2a, RF/50. A stored bit value of 0 is sent as fc/8 (high sub-carrier) and
+// 1 as fc/10. Verified against a real Farpointe tag captured with this device:
+// the leading preamble zeros are fc/8 and the bit values match the tag exactly.
+//
+// Unlike HID/ioProx, which emit a fixed integer number of sub-carrier cycles
+// per bit, Pyramid REQUIRES exact RF/50 bit-period alignment: its frame opens
+// with a 15-bit run of zeros (all fc/8). counter_top=8 does not divide the
+// 50-tick bit period, so a fixed 6 cycles (48 ticks) runs 2 ticks short per
+// bit; across the preamble that accumulates past a full bit and a reader (e.g.
+// Proxmark, which demods at a fixed RF/50 clock) drops a preamble bit and fails
+// to match. We instead use a phase accumulator: emit whole sub-carrier cycles
+// until the cumulative tick count reaches each bit's exact (i+1)*50 boundary.
+// fc/10 is always 5 cycles (10|50); fc/8 self-corrects between 6 and 7 cycles
+// (avg 6.25 = 50 ticks), so bit boundaries never drift.
+#define PYRAMID_FC_HI_TOP (8)    // fc/8  @ 125kHz base (bit value 0)
+#define PYRAMID_FC_LO_TOP (10)   // fc/10 @ 125kHz base (bit value 1)
+#define PYRAMID_BIT_TICKS (50)   // RF/50: carrier ticks per data bit
+
+// Worst case is all-fc/8: ceil(128*50/8) = 800 cycles. Round up for headroom.
+static nrf_pwm_values_wave_form_t m_pyramid_pwm_seq_vals[PYRAMID_RAW_BITS * 7] = {};
+
+static nrf_pwm_sequence_t m_pyramid_pwm_seq = {
+    .values.p_wave_form = m_pyramid_pwm_seq_vals,
+    .length = NRF_PWM_VALUES_LENGTH(m_pyramid_pwm_seq_vals),
+    .repeats = 0,
+    .end_delay = 0,
+};
+
+static void *pyramid_codec_alloc(void) {
+    pyramid_codec_t *d = (pyramid_codec_t *)malloc(sizeof(pyramid_codec_t));
+    if (!d) return NULL;
+    memset(d, 0, sizeof(*d));
+    // RF/50 FSK demod, same modulation / bitrate as HID Prox. Enable the
+    // running DC baseline tracker: the raw 14-bit ADC DC otherwise swamps the
+    // fc/8 Goertzel bin and pins every bit to 0.
+    d->modem = fsk_alloc(FSK_BITRATE_HID);
+    if (d->modem) {
+        d->modem->dc_block = true;
+    }
+    return d;
+}
+
+static void pyramid_codec_free(void *codec) {
+    pyramid_codec_t *d = (pyramid_codec_t *)codec;
+    if (!d) return;
+    if (d->modem) {
+        fsk_free(d->modem);
+        d->modem = NULL;
+    }
+    free(d);
+}
+
+static uint8_t *pyramid_get_data(void *codec) {
+    return ((pyramid_codec_t *)codec)->data;
+}
+
+// FSK2a modulator: replay the raw 128-bit frame MSB-first as a PWM sequence,
+// keeping every bit boundary aligned to RF/50 via a tick-count accumulator.
+const nrf_pwm_sequence_t *pyramid_modulator(pyramid_codec_t *d, uint8_t *buf) {
+    (void)d;
+
+    int k = 0;
+    uint32_t emitted = 0;  // total carrier ticks emitted so far
+
+    for (int bi = 0; bi < PYRAMID_RAW_BITS; bi++) {
+        bool bit = (buf[bi >> 3] >> (7 - (bi & 7))) & 1u;
+        uint16_t top = bit ? PYRAMID_FC_LO_TOP : PYRAMID_FC_HI_TOP;
+        uint32_t boundary = (uint32_t)(bi + 1) * PYRAMID_BIT_TICKS;
+
+        // Emit whole sub-carrier cycles until we reach this bit's tick boundary.
+        while (emitted < boundary) {
+            m_pyramid_pwm_seq_vals[k].channel_0   = top / 2;  // 50% duty
+            m_pyramid_pwm_seq_vals[k].counter_top = top;
+            k++;
+            emitted += top;
+        }
+    }
+
+    m_pyramid_pwm_seq.length = (uint16_t)(k * 4);
+    return &m_pyramid_pwm_seq;
+}
+
+// ---------------------------------------------------------------------------
+// Reader / decoder
+//
+// FSK demod (fsk_feed) yields one raw bit per RF/50 window; bits accumulate in
+// a ring buffer. We scan for the 24-bit Pyramid preamble {0x15 zeros, 1, 0x7
+// zeros, 1} and validate a candidate 128-bit frame three ways before accepting
+// it: 24-bit preamble, odd parity on every 8-bit group (bits 8..127), and a
+// CRC-8/Maxim trailer over the 13 payload bytes. With all three gates a false
+// positive is effectively impossible, so a single frame match is enough.
+// ---------------------------------------------------------------------------
+
+// 24-bit preamble: fifteen 0s, a 1, seven 0s, a 1 (matches Proxmark detectPyramid)
+static const uint8_t PYRAMID_PREAMBLE[24] = {
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1,
+    0, 0, 0, 0, 0, 0, 0, 1,
+};
+
+// Reads n bits MSB-first from bits[off] into an integer.
+static uint32_t bits_to_u32(const uint8_t *bits, uint16_t off, uint8_t n) {
+    uint32_t v = 0;
+    for (uint8_t i = 0; i < n; i++) {
+        v = (v << 1) | (bits[off + i] & 1u);
+    }
+    return v;
+}
+
+// CRC-8/Maxim (Dallas 1-Wire): poly 0x31 reflected (0x8C), init 0x00.
+static uint8_t pyramid_crc8_maxim(const uint8_t *data, uint8_t len) {
+    uint8_t crc = 0;
+    for (uint8_t i = 0; i < len; i++) {
+        crc ^= data[i];
+        for (uint8_t b = 0; b < 8; b++) {
+            crc = (crc & 1u) ? (uint8_t)((crc >> 1) ^ 0x8Cu) : (uint8_t)(crc >> 1);
+        }
+    }
+    return crc;
+}
+
+static void pyramid_reset_bits(pyramid_codec_t *d) {
+    d->bit_len = 0;
+}
+
+static inline void pyramid_push_bit(pyramid_codec_t *d, uint8_t bit) {
+    if (d->bit_len < PYRAMID_MAX_BITS) {
+        d->bits[d->bit_len++] = bit;
+        return;
+    }
+    // Buffer full: drop the oldest bit and append the new one
+    memmove(d->bits, d->bits + 1, PYRAMID_MAX_BITS - 1);
+    d->bits[PYRAMID_MAX_BITS - 1] = bit;
+}
+
+// Validates and unpacks the 128-bit frame whose preamble starts at idx.
+// Requires idx + 128 <= bit_len. On success packs the raw 16 bytes into d->data.
+static bool pyramid_try_decode(pyramid_codec_t *d, uint16_t idx) {
+    const uint8_t *b = d->bits;
+
+    // Odd parity on every 8-bit group of bits 8..127 (15 groups, 7 data + 1 parity)
+    for (uint16_t g = idx + 8; g < idx + 128; g += 8) {
+        uint32_t grp = bits_to_u32(b, g, 8);
+        if ((__builtin_popcount(grp) & 1u) == 0u) {
+            return false;  // group must have odd parity
+        }
+    }
+
+    // CRC-8/Maxim over the 13 payload bytes (bits 16..119) vs trailer (bits 120..127)
+    uint8_t cs[13];
+    for (uint8_t i = 0; i < 13; i++) {
+        cs[i] = (uint8_t)bits_to_u32(b, (uint16_t)(idx + 16 + i * 8), 8);
+    }
+    uint8_t checksum = (uint8_t)bits_to_u32(b, (uint16_t)(idx + 120), 8);
+    if (pyramid_crc8_maxim(cs, 13) != checksum) {
+        return false;
+    }
+
+    // Valid: pack the raw 128-bit frame MSB-first into the 16-byte output
+    for (uint8_t i = 0; i < PYRAMID_DATA_SIZE; i++) {
+        d->data[i] = (uint8_t)bits_to_u32(b, (uint16_t)(idx + i * 8), 8);
+    }
+    return true;
+}
+
+// Scans the bit buffer for a valid frame anchored on the 24-bit preamble.
+static bool pyramid_scan(pyramid_codec_t *d) {
+    if (d->bit_len < PYRAMID_RAW_BITS) return false;
+
+    for (uint16_t i = 0; (uint16_t)(i + PYRAMID_RAW_BITS) <= d->bit_len; i++) {
+        bool pre_ok = true;
+        for (uint8_t k = 0; k < sizeof(PYRAMID_PREAMBLE); k++) {
+            if ((d->bits[i + k] & 1u) != PYRAMID_PREAMBLE[k]) {
+                pre_ok = false;
+                break;
+            }
+        }
+        if (!pre_ok) continue;
+        if (pyramid_try_decode(d, i)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+static void pyramid_decoder_start(void *codec, uint8_t format_hint) {
+    (void)format_hint;
+    pyramid_codec_t *d = (pyramid_codec_t *)codec;
+    d->bit_len = 0;
+    memset(d->bits, 0, sizeof(d->bits));
+    memset(d->data, 0, sizeof(d->data));
+}
+
+static bool pyramid_decoder_feed(void *codec, uint16_t val) {
+    pyramid_codec_t *d = (pyramid_codec_t *)codec;
+    if (!d || !d->modem) return false;
+
+    bool bit = false;
+    if (!fsk_feed(d->modem, val, &bit)) {
+        return false;
+    }
+
+    pyramid_push_bit(d, (uint8_t)(bit ? 1u : 0u));
+
+    if (d->bit_len >= PYRAMID_RAW_BITS) {
+        if (pyramid_scan(d)) {
+            pyramid_reset_bits(d);
+            return true;
+        }
+    }
+    return false;
+}
+
+const protocol pyramid = {
+    .tag_type = TAG_TYPE_FARPOINTE_PYRAMID,
+    .data_size = PYRAMID_DATA_SIZE,
+    .alloc = (codec_alloc)pyramid_codec_alloc,
+    .free = (codec_free)pyramid_codec_free,
+    .get_data = (codec_get_data)pyramid_get_data,
+    .modulator = (modulator)pyramid_modulator,
+    .decoder = {
+        .start = (decoder_start)pyramid_decoder_start,
+        .feed  = (decoder_feed)pyramid_decoder_feed,
+    },
+};

--- a/firmware/application/src/rfid/nfctag/lf/protocols/pyramid.h
+++ b/firmware/application/src/rfid/nfctag/lf/protocols/pyramid.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <stdint.h>
+#include "protocols.h"
+#include "fskdemod.h"
+
+// Farpointe / Pyramid (FSK2a, RF/50, 128-bit frame).
+//
+// Emulation: the full 128-bit on-air frame (preamble + Wiegand data + parity +
+// CRC) is stored verbatim as 16 bytes and replayed by the modulator; no
+// encoding is performed on-device.
+//
+// Reading: ADC samples are FSK-demodulated to a raw bitstream, the 24-bit
+// preamble {0x15, 1, 0x7, 1} is located, then odd parity (every 8th bit) and a
+// CRC-8/Maxim trailer are validated. The 16-byte frame recovered on a valid
+// read matches the emulation layout, so a read result can be written straight
+// into a slot. Card number / format length are decoded host-side by the CLI.
+
+#define PYRAMID_DATA_SIZE 16   // 128-bit frame, MSB-first
+#define PYRAMID_RAW_BITS 128
+#define PYRAMID_MAX_BITS 256   // bit ring buffer for the reader (~2 frames)
+
+typedef struct {
+    fsk_t *modem;                   // FSK demodulator (reader path only)
+    uint8_t bits[PYRAMID_MAX_BITS]; // recovered raw bitstream
+    uint16_t bit_len;
+    uint8_t data[PYRAMID_DATA_SIZE];
+} pyramid_codec_t;
+
+extern const protocol pyramid;

--- a/firmware/application/src/rfid/nfctag/lf/utils/fskdemod.c
+++ b/firmware/application/src/rfid/nfctag/lf/utils/fskdemod.c
@@ -7,7 +7,7 @@
 #define PI 3.14159265358979f
 #define GOERTZEL(FREQ, SAMPLE_RATE) (2.0 * cos((2.0 * PI * FREQ) / (SAMPLE_RATE)))
 
-float goertzel_mag(float coef, uint16_t samples[], int n) {
+static float goertzel_power(float coef, const uint16_t samples[], int n) {
     float z1 = 0;
     float z2 = 0;
     for (int i = 0; i < n; i++) {
@@ -15,7 +15,11 @@ float goertzel_mag(float coef, uint16_t samples[], int n) {
         z2 = z1;
         z1 = z0;
     }
-    return sqrt(z1 * z1 + z2 * z2 - coef * z1 * z2);
+    // Squared magnitude (|X|^2). The bit decision only compares two of these,
+    // and power is monotonic with magnitude, so the sqrt is dropped entirely.
+    // Result can be slightly negative from rounding; harmless for a comparison
+    // (and avoids the sqrt(NaN) the old magnitude version could hit near zero).
+    return z1 * z1 + z2 * z2 - coef * z1 * z2;
 }
 
 void fsk_free(fsk_t *m) {
@@ -33,8 +37,8 @@ bool fsk_feed(fsk_t *m, uint16_t sample, bool *bit) {
     if (m->c < m->bitrate) {
         return false;
     }
-    float bit0 = goertzel_mag(m->goertzel_fc_8,  m->samples, m->bitrate);
-    float bit1 = goertzel_mag(m->goertzel_fc_10, m->samples, m->bitrate);
+    float bit0 = goertzel_power(m->goertzel_fc_8,  m->samples, m->bitrate);
+    float bit1 = goertzel_power(m->goertzel_fc_10, m->samples, m->bitrate);
     *bit = (bit1 > bit0);
 
     // Reset counter and clear sample buffer for the next bit

--- a/firmware/application/src/rfid/nfctag/lf/utils/fskdemod.c
+++ b/firmware/application/src/rfid/nfctag/lf/utils/fskdemod.c
@@ -7,18 +7,26 @@
 #define PI 3.14159265358979f
 #define GOERTZEL(FREQ, SAMPLE_RATE) (2.0 * cos((2.0 * PI * FREQ) / (SAMPLE_RATE)))
 
-static float goertzel_power(float coef, const uint16_t samples[], int n) {
+// Goertzel squared magnitude (|X|^2) with an optional DC offset subtracted from
+// each sample.
+//
+// No sqrt: the bit decision only compares two of these and power is monotonic
+// with magnitude, so the sqrt is dropped (the Cortex-M4F FPU has no double
+// hardware; a double sqrt() would pull in a soft-float routine). The result can
+// round slightly negative near zero signal, which is harmless for a comparison.
+//
+// DC offset: a 50-sample (RF/50) window holds an integer number of fc/10 cycles
+// but a non-integer count of fc/8, so the raw ADC's DC component leaks into the
+// fc/8 bin and biases the decision toward fc/8. Subtracting a running baseline
+// (dc) removes that bias; pass dc=0 for the legacy behaviour.
+static float goertzel_power(float coef, const uint16_t samples[], int n, float dc) {
     float z1 = 0;
     float z2 = 0;
     for (int i = 0; i < n; i++) {
-        float z0 = coef * z1 - z2 + (float)(samples[i]);
+        float z0 = coef * z1 - z2 + ((float)samples[i] - dc);
         z2 = z1;
         z1 = z0;
     }
-    // Squared magnitude (|X|^2). The bit decision only compares two of these,
-    // and power is monotonic with magnitude, so the sqrt is dropped entirely.
-    // Result can be slightly negative from rounding; harmless for a comparison
-    // (and avoids the sqrt(NaN) the old magnitude version could hit near zero).
     return z1 * z1 + z2 * z2 - coef * z1 * z2;
 }
 
@@ -33,12 +41,25 @@ void fsk_free(fsk_t *m) {
  * multiple protocols with different speeds.
  */
 bool fsk_feed(fsk_t *m, uint16_t sample, bool *bit) {
+    if (m->dc_block) {
+        // Slow IIR baseline tracker (time const ~64 samples). Removes the large
+        // raw-ADC DC offset that otherwise leaks into the fc/8 Goertzel bin and
+        // pins every decision to bit 0. Unlike a per-window mean, a running
+        // baseline does not distort fc/8's non-integer cycle count in a window.
+        if (!m->dc_seen) {
+            m->dc_run = (float)sample;
+            m->dc_seen = true;
+        } else {
+            m->dc_run += ((float)sample - m->dc_run) * (1.0f / 64.0f);
+        }
+    }
     m->samples[m->c++] = sample;
     if (m->c < m->bitrate) {
         return false;
     }
-    float bit0 = goertzel_power(m->goertzel_fc_8,  m->samples, m->bitrate);
-    float bit1 = goertzel_power(m->goertzel_fc_10, m->samples, m->bitrate);
+    float dc = m->dc_block ? m->dc_run : 0.0f;
+    float bit0 = goertzel_power(m->goertzel_fc_8,  m->samples, m->bitrate, dc);
+    float bit1 = goertzel_power(m->goertzel_fc_10, m->samples, m->bitrate, dc);
     *bit = (bit1 > bit0);
 
     // Reset counter and clear sample buffer for the next bit
@@ -61,6 +82,9 @@ fsk_t *fsk_alloc(uint8_t bitrate) {
 
     m->bitrate = bitrate;
     m->c = 0;
+    m->dc_block = false;
+    m->dc_seen = false;
+    m->dc_run = 0.0f;
     m->goertzel_fc_8 = GOERTZEL(15625.0f, 125000.0f);
     m->goertzel_fc_10 = GOERTZEL(12500.0f, 125000.0f);
     return m;

--- a/firmware/application/src/rfid/nfctag/lf/utils/fskdemod.h
+++ b/firmware/application/src/rfid/nfctag/lf/utils/fskdemod.h
@@ -14,6 +14,9 @@ extern "C" {
 typedef struct {
     uint8_t bitrate; // 50 or 64
     uint8_t c;
+    bool dc_block;   // subtract a running DC baseline before Goertzel (off by default)
+    bool dc_seen;    // running-baseline initialised
+    float dc_run;    // IIR-tracked DC baseline
     uint16_t samples[FSK_MAX_BITRATE];
     float goertzel_fc_8;
     float goertzel_fc_10;

--- a/firmware/application/src/rfid/nfctag/tag_base_type.h
+++ b/firmware/application/src/rfid/nfctag/tag_base_type.h
@@ -55,6 +55,8 @@ typedef enum {
     //////// FSK Tag-Talk-First   200
     TAG_TYPE_HID_PROX = 200,
     TAG_TYPE_IOPROX,
+    // Farpointe / Pyramid (FSK2a, RF/50) — read + emulation
+    TAG_TYPE_FARPOINTE_PYRAMID,
     // AWID
     // Paradox
 
@@ -111,7 +113,7 @@ typedef enum {
     }
 
 #define TAG_SPECIFIC_TYPE_LF_VALUES \
-    TAG_TYPE_EM410X, TAG_TYPE_EM410X_ELECTRA, TAG_TYPE_PAC, TAG_TYPE_HID_PROX, TAG_TYPE_IOPROX, TAG_TYPE_VIKING, TAG_TYPE_JABLOTRON, TAG_TYPE_IDTECK
+    TAG_TYPE_EM410X, TAG_TYPE_EM410X_ELECTRA, TAG_TYPE_PAC, TAG_TYPE_HID_PROX, TAG_TYPE_IOPROX, TAG_TYPE_FARPOINTE_PYRAMID, TAG_TYPE_VIKING, TAG_TYPE_JABLOTRON, TAG_TYPE_IDTECK
 
 // Tag types that use PSK1 modulation for emulation. These require the PWM
 // base clock to be set to 1MHz (see lf_tag_em.c pwm_init) so the 16us

--- a/firmware/application/src/rfid/nfctag/tag_emulation.c
+++ b/firmware/application/src/rfid/nfctag/tag_emulation.c
@@ -98,6 +98,7 @@ static tag_base_handler_map_t tag_base_map[] = {
     {TAG_SENSE_LF, TAG_TYPE_PAC,         lf_tag_data_loadcb,           lf_tag_pac_data_savecb,       lf_tag_pac_data_factory,       &m_tag_data_lf},
     {TAG_SENSE_LF, TAG_TYPE_JABLOTRON,   lf_tag_data_loadcb,           lf_tag_jablotron_data_savecb, lf_tag_jablotron_data_factory, &m_tag_data_lf},
     {TAG_SENSE_LF, TAG_TYPE_IDTECK,      lf_tag_data_loadcb,           lf_tag_idteck_data_savecb,    lf_tag_idteck_data_factory,    &m_tag_data_lf},
+    {TAG_SENSE_LF, TAG_TYPE_FARPOINTE_PYRAMID, lf_tag_data_loadcb,     lf_tag_pyramid_data_savecb,   lf_tag_pyramid_data_factory,   &m_tag_data_lf},
     // MF1 tag emulation
     {TAG_SENSE_HF, TAG_TYPE_MIFARE_Mini, nfc_tag_mf1_data_loadcb,      nfc_tag_mf1_data_savecb,      nfc_tag_mf1_data_factory,      &m_tag_data_hf},
     {TAG_SENSE_HF, TAG_TYPE_MIFARE_1024, nfc_tag_mf1_data_loadcb,      nfc_tag_mf1_data_savecb,      nfc_tag_mf1_data_factory,      &m_tag_data_hf},

--- a/firmware/application/src/rfid/reader/lf/lf_pyramid_data.c
+++ b/firmware/application/src/rfid/reader/lf/lf_pyramid_data.c
@@ -1,0 +1,111 @@
+#include "bsp_delay.h"
+#include "bsp_time.h"
+#include "circular_buffer.h"
+#include "lf_125khz_radio.h"
+#include "lf_reader_data.h"
+#include "lf_reader_main.h"
+#include "nrfx_saadc.h"
+#include "protocols/pyramid.h"
+#include "time.h"
+#include "rfid_main.h"
+
+#define NRF_LOG_MODULE_NAME lf_pyramid
+#include "nrf_log.h"
+#include "nrf_log_ctrl.h"
+#include "nrf_log_default_backends.h"
+NRF_LOG_MODULE_REGISTER();
+
+#define PYRAMID_BUFFER_SIZE (6144)
+
+static circular_buffer cb;
+
+// Generation counters used to disarm the SAADC callback without a mutex.
+// g_lf_gen is bumped on each new read. g_lf_active_gen is set to the current
+// generation before enabling SAADC; the callback drops samples whose generation
+// no longer matches.
+static volatile uint32_t g_lf_gen        = 0;
+static volatile uint32_t g_lf_active_gen = 0;
+
+static void saadc_cb(nrf_saadc_value_t *vals, size_t size) {
+    // Snapshot the generation counter once to avoid repeated volatile reads
+    uint32_t gen = g_lf_active_gen;
+    if (gen == 0) return; // Not armed, ignore
+
+    for (size_t i = 0; i < size; i++) {
+        // Check if we were disarmed mid-batch
+        if (g_lf_active_gen != gen) return;
+        uint16_t v = (uint16_t)vals[i];
+        cb_push_back(&cb, &v);
+    }
+}
+
+static void init_pyramid_hw(void) {
+    uint16_t dump   = 0;
+    uint32_t my_gen = 0;
+
+    // Stop the radio and disable SAADC before restarting (discharges the card)
+    stop_lf_125khz_radio();
+    lf_125khz_radio_saadc_disable();
+
+    // Guard time: allow the card chip to fully reset (20-50 ms suits most 125 kHz cards)
+    bsp_delay_ms(50);
+
+    // Flush any stale samples from the circular buffer
+    while (cb_pop_front(&cb, &dump)) {}
+
+    // Arm the SAADC callback before enabling RF so no early samples are missed
+    my_gen          = ++g_lf_gen;
+    g_lf_active_gen = my_gen;
+
+    // Start the RF field and allow the card power to stabilize
+    start_lf_125khz_radio();
+    bsp_delay_ms(10);
+
+    // Enable SAADC sampling now that the card has powered up
+    lf_125khz_radio_saadc_enable(saadc_cb);
+}
+
+static void uninit_pyramid_hw(void) {
+    uint16_t dump = 0;
+
+    // Disarm first to stop the SAADC callback from pushing new samples
+    g_lf_active_gen = 0;
+
+    // Stop RF field and SAADC
+    stop_lf_125khz_radio();
+    lf_125khz_radio_saadc_disable();
+
+    // Flush samples that arrived between disarm and SAADC stop
+    while (cb_pop_front(&cb, &dump)) {}
+}
+
+bool pyramid_read(uint8_t *data, uint32_t timeout_ms) {
+    void      *codec = NULL;
+    autotimer *p_at  = NULL;
+    uint16_t   val   = 0;
+    bool       ok    = false;
+
+    codec = pyramid.alloc();
+    pyramid.decoder.start(codec, 0);
+
+    cb_init(&cb, PYRAMID_BUFFER_SIZE, sizeof(uint16_t));
+    init_pyramid_hw();
+
+    p_at = bsp_obtain_timer(0);
+
+    while (!ok && NO_TIMEOUT_1MS(p_at, timeout_ms)) {
+        while (!ok && NO_TIMEOUT_1MS(p_at, timeout_ms) && cb_pop_front(&cb, &val)) {
+            if (pyramid.decoder.feed(codec, val)) {
+                memcpy(data, pyramid.get_data(codec), pyramid.data_size);
+                ok = true;
+            }
+        }
+    }
+
+    bsp_return_timer(p_at);
+    uninit_pyramid_hw();
+    cb_free(&cb);
+    pyramid.free(codec);
+
+    return ok;
+}

--- a/firmware/application/src/rfid/reader/lf/lf_reader_data.h
+++ b/firmware/application/src/rfid/reader/lf/lf_reader_data.h
@@ -24,6 +24,7 @@ bool hidprox_read(uint8_t *data, uint8_t format_hint, uint32_t timeout_ms);
 bool pac_read(uint8_t *data, uint32_t timeout_ms);
 bool viking_read(uint8_t *data, uint32_t timeout_ms);
 bool jablotron_read(uint8_t *data, uint32_t timeout_ms);
+bool pyramid_read(uint8_t *data, uint32_t timeout_ms);
 
 bool raw_read_to_buffer(uint8_t *data, size_t maxlen, uint32_t timeout_ms, size_t *outlen);
 

--- a/firmware/application/src/rfid/reader/lf/lf_reader_main.c
+++ b/firmware/application/src/rfid/reader/lf/lf_reader_main.c
@@ -14,6 +14,7 @@
 #include "protocols/jablotron.h"
 #include "protocols/pac.h"
 #include "protocols/viking.h"
+#include "protocols/pyramid.h"
 
 #define NRF_LOG_MODULE_NAME lf_main
 #include "nrf_log.h"
@@ -109,6 +110,16 @@ uint8_t scan_viking(uint8_t *uid) {
  */
 uint8_t scan_jablotron(uint8_t *uid) {
     if (jablotron_read(uid, g_timeout_readem_ms)) {
+        return STATUS_LF_TAG_OK;
+    }
+    return STATUS_LF_TAG_NO_FOUND;
+}
+
+/**
+ * Search Farpointe/Pyramid tag
+ */
+uint8_t scan_pyramid(uint8_t *data) {
+    if (pyramid_read(data, g_timeout_readem_ms)) {
         return STATUS_LF_TAG_OK;
     }
     return STATUS_LF_TAG_NO_FOUND;

--- a/firmware/application/src/rfid/reader/lf/lf_reader_main.h
+++ b/firmware/application/src/rfid/reader/lf/lf_reader_main.h
@@ -19,6 +19,7 @@ uint8_t scan_hidprox(uint8_t *uid, uint8_t format_hint);
 uint8_t scan_pac(uint8_t *card_id);
 uint8_t scan_viking(uint8_t *uid);
 uint8_t scan_jablotron(uint8_t *uid);
+uint8_t scan_pyramid(uint8_t *data);
 uint8_t write_em410x_to_t55xx(uint8_t *uid, uint8_t *newkey, uint8_t *old_keys, uint8_t old_key_count);
 uint8_t write_em410x_electra_to_t55xx(uint8_t *uid, uint8_t *newkey, uint8_t *old_keys, uint8_t old_key_count);
 uint8_t write_hidprox_to_t55xx(uint8_t format, uint32_t fc, uint64_t cn, uint32_t il, uint32_t oem, uint8_t *new_passwd, uint8_t *old_passwds, uint8_t old_passwd_count);

--- a/software/script/chameleon_cli_unit.py
+++ b/software/script/chameleon_cli_unit.py
@@ -900,6 +900,7 @@ lf_viking = lf.subgroup("viking", "Viking commands")
 lf_jablotron = lf.subgroup("jablotron", "Jablotron commands")
 lf_generic = lf.subgroup("generic", "Generic commands")
 lf_idteck = lf.subgroup("idteck", "IDTECK commands")
+lf_pyramid = lf.subgroup("pyramid", "Farpointe/Pyramid commands")
 
 
 @root.command("clear")
@@ -6961,6 +6962,59 @@ class LFJablotronRead(ReaderRequiredUnit):
         card_id = jablotron_card_id(id)
         print(f" Jablotron ID: {color_string((CG, id.hex().upper()))}")
         print(f" Card number:  {color_string((CY, str(card_id)))}")
+
+
+def pyramid_decode(raw: bytes):
+    """Decode a 16-byte (128-bit) Farpointe/Pyramid frame.
+
+    Mirrors Proxmark's demodPyramid: strip the odd-parity bit from every 8-bit
+    group of bits 8..127 (15 groups -> 105 data bits), find the leading-1
+    format sentinel, then read facility code / card number per the detected
+    format length. Returns (fmt_len, facility_code_or_None, card_number).
+    """
+    if len(raw) != 16:
+        raise ValueError("Pyramid frame must be exactly 16 bytes (128 bits)")
+    bits = [(raw[i >> 3] >> (7 - (i & 7))) & 1 for i in range(128)]
+
+    # strip odd parity: 15 groups of 8 (bits 8..127) -> 105 data bits
+    dep = []
+    for word in range(8, 128, 8):
+        dep.extend(bits[word:word + 7])  # keep 7 data bits, drop parity
+
+    def d2i(off, n):
+        v = 0
+        for i in range(n):
+            v = (v << 1) | dep[off + i]
+        return v
+
+    # leading-1 sentinel marks the start of the format field
+    j = next((i for i, v in enumerate(dep) if v), len(dep))
+    fmt_len = len(dep) - j - 8
+
+    if fmt_len == 26:
+        return fmt_len, d2i(73, 8), d2i(81, 16)
+    elif fmt_len == 45:
+        return 42, d2i(53, 10), d2i(63, 32)
+    else:
+        return fmt_len, None, d2i(81, 16)
+
+
+@lf_pyramid.command("read")
+class LFPyramidRead(ReaderRequiredUnit):
+    def args_parser(self) -> ArgumentParserNoExit:
+        parser = ArgumentParserNoExit()
+        parser.description = "Scan a Farpointe/Pyramid tag and print card number and raw frame"
+        return parser
+
+    def on_exec(self, args: argparse.Namespace):
+        raw = self.cmd.pyramid_scan()
+        fmt_len, fc, card = pyramid_decode(raw)
+        print(f"Farpointe/Pyramid")
+        print(f"   Format length: {color_string((CG, str(fmt_len)))}")
+        if fc is not None:
+            print(f"   Facility:      {color_string((CG, f'{fc} [0x{fc:02X}]'))}")
+        print(f"   Card number:   {color_string((CY, str(card)))}")
+        print(f"   Raw:           {color_string((CY, raw.hex().upper()))}")
 
 
 @lf_jablotron.command("write")

--- a/software/script/chameleon_cmd.py
+++ b/software/script/chameleon_cmd.py
@@ -800,6 +800,17 @@ class ChameleonCMD:
         return resp
 
     @expect_response(Status.LF_TAG_OK)
+    def pyramid_scan(self):
+        """
+        Read a Farpointe/Pyramid tag. Returns the raw 16-byte (128-bit) frame;
+        the card number and format length are decoded host-side by the CLI.
+        """
+        resp = self.device.send_cmd_sync(Command.PYRAMID_SCAN)
+        if resp.status == Status.LF_TAG_OK:
+            resp.parsed = resp.data[:16]
+        return resp
+
+    @expect_response(Status.LF_TAG_OK)
     def jablotron_write_to_t55xx(self, id_bytes: bytes):
         """
         Write Jablotron card number into T55XX.

--- a/software/script/chameleon_enum.py
+++ b/software/script/chameleon_enum.py
@@ -100,6 +100,7 @@ class Command(enum.IntEnum):
     IDTECK_WRITE_TO_T55XX = 3018
     JABLOTRON_SCAN = 3019
     JABLOTRON_WRITE_TO_T55XX = 3020
+    PYRAMID_SCAN = 3021
 
     MF1_WRITE_EMU_BLOCK_DATA = 4000
     HF14A_SET_ANTI_COLL_DATA = 4001
@@ -318,6 +319,7 @@ class TagSpecificType(enum.IntEnum):
     # FSK Tag-Talk-First      200
     HIDProx = 200
     ioProx = 201
+    Pyramid = 202
     # AWID
     # Paradox
 
@@ -404,6 +406,8 @@ class TagSpecificType(enum.IntEnum):
             return "HIDProx"
         elif self == TagSpecificType.ioProx:
             return "ioProx"
+        elif self == TagSpecificType.Pyramid:
+            return "Farpointe/Pyramid"
         elif self == TagSpecificType.PAC:
             return "PAC/Stanley"
         elif self == TagSpecificType.Viking:


### PR DESCRIPTION
This adds support for reading and emulation Farpointe Pyramid tags - 125 kHz LF FSK2a modulation at RF/50 (from proxmark codebase and known documentation).

Depends on the work done on the general FSK demod in #452 - the tag in question I have here is always just a bit weakly coupled.

I have also based it on top of #451 - that can be easily removed if needed.

Tested with my CU and proxmark3 as well as against original Pyramid FSK reader.

PS: Sorry for using claude for this, not proud but RF is hard:(