### PR TITLE
fix(mf1): clear AuthenticatedSector on reset handler

### DIFF
--- a/firmware/application/src/rfid/nfctag/hf/nfc_mf1.c
+++ b/firmware/application/src/rfid/nfctag/hf/nfc_mf1.c
@@ -1227,6 +1227,7 @@ void nfc_tag_mf1_reset_handler() {
     m_mf1_state = MF1_STATE_UNAUTHENTICATED;
     m_gen1a_state = GEN1A_STATE_DISABLE;
     nfc_tag_14a_set_state(NFC_TAG_STATE_14A_IDLE);
+    AuthenticatedSector = 0xFF;  //Fix missig Authentication variable
 
 #ifndef NFC_MF1_FAST_SIM
     // Must to reset pcs handler


### PR DESCRIPTION
Prevents stale sector authentication state from blocking access to
higher sectors when switching between cards of different sizes.

Fixes v2.2.0 regression (PR #274) where 4K Mifare Classic emulation
fails after authenticating on 1K card. The reset handler was not
clearing AuthenticatedSector, causing sector boundary checks to reject
all access to 4K sectors 16-39 as "out of authenticated sector".