### PR TITLE
Feat/paradox fsk support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project uses the changelog in accordance with [keepchangelog](http://keepac
 
 ## [unreleased][unreleased]
 
+ - Added Paradox LF protocol support for reading and emulation, including CLI commands to read, inspect demodulated data, and configure stored credentials (@Obertura777)
+
 ## [v2.2.0][2026-07-04]
  - Added Jablotron LF protocol support: read, emulate and T55xx clone (@midlan)
  - Added IDTECK LF protocol support: tag emulation (PSK1 RF/32) and T55xx clone. No reader path yet; PSK demodulation on the envelope-only receive chain is left for a follow-up.

--- a/firmware/application/Makefile
+++ b/firmware/application/Makefile
@@ -41,6 +41,7 @@ SRC_FILES += \
   $(PROJ_DIR)/rfid/nfctag/lf/protocols/hidprox.c \
   $(PROJ_DIR)/rfid/nfctag/lf/protocols/pac.c \
   $(PROJ_DIR)/rfid/nfctag/lf/protocols/ioprox.c \
+  $(PROJ_DIR)/rfid/nfctag/lf/protocols/paradox.c \
   $(PROJ_DIR)/rfid/nfctag/lf/protocols/viking.c \
   $(PROJ_DIR)/rfid/nfctag/lf/protocols/jablotron.c \
   $(PROJ_DIR)/rfid/nfctag/lf/utils/diphase.c \
@@ -357,6 +358,7 @@ ifeq	(${CURRENT_DEVICE_TYPE}, ${CHAMELEON_ULTRA})
     $(PROJ_DIR)/rfid/reader/lf/lf_hidprox_data.c \
     $(PROJ_DIR)/rfid/reader/lf/lf_pac_data.c \
     $(PROJ_DIR)/rfid/reader/lf/lf_ioprox_data.c \
+    $(PROJ_DIR)/rfid/reader/lf/lf_paradox_data.c \
     $(PROJ_DIR)/rfid/reader/lf/lf_viking_data.c \
     $(PROJ_DIR)/rfid/reader/lf/lf_jablotron_data.c \
 

--- a/firmware/application/src/app_cmd.c
+++ b/firmware/application/src/app_cmd.c
@@ -753,6 +753,24 @@ static data_frame_tx_t *cmd_processor_ioprox_scan(uint16_t cmd, uint16_t status,
     return data_frame_make(cmd, STATUS_LF_TAG_OK, sizeof(card_data), card_data);
 }
 
+static data_frame_tx_t *cmd_processor_paradox_scan(uint16_t cmd, uint16_t status, uint16_t length, uint8_t *data) {
+    uint8_t card_data[LF_PARADOX_TAG_ID_SIZE] = {0};
+    status = scan_paradox(card_data);
+    if (status != STATUS_LF_TAG_OK) {
+        return data_frame_make(cmd, status, 0, NULL);
+    }
+    return data_frame_make(cmd, STATUS_LF_TAG_OK, sizeof(card_data), card_data);
+}
+
+static data_frame_tx_t *cmd_processor_paradox_get_last_demod(uint16_t cmd, uint16_t status, uint16_t length, uint8_t *data) {
+    uint8_t demod[29];
+    size_t demod_length = paradox_get_last_demod(demod, sizeof(demod));
+    if (demod_length == 0) {
+        return data_frame_make(cmd, STATUS_PAR_ERR, 0, NULL);
+    }
+    return data_frame_make(cmd, STATUS_SUCCESS, demod_length, demod);
+}
+
 static data_frame_tx_t *cmd_processor_ioprox_write_to_t55xx(uint16_t cmd, uint16_t status, uint16_t length, uint8_t *data) {
     typedef struct {
         uint8_t card_data[16];  // ioprox_codec_t->data layout: version, facility code, card number, raw8
@@ -1141,6 +1159,26 @@ static data_frame_tx_t *cmd_processor_ioprox_set_emu_id(uint16_t cmd, uint16_t s
     memcpy(buffer->buffer, data, LF_IOPROX_TAG_ID_SIZE);
     tag_emulation_load_by_buffer(TAG_TYPE_IOPROX, false);
     return data_frame_make(cmd, STATUS_SUCCESS, 0, NULL);
+}
+
+static data_frame_tx_t *cmd_processor_paradox_set_emu_id(uint16_t cmd, uint16_t status, uint16_t length, uint8_t *data) {
+    if (length != LF_PARADOX_TAG_ID_SIZE) {
+        return data_frame_make(cmd, STATUS_PAR_ERR, 0, NULL);
+    }
+    tag_data_buffer_t *buffer = get_buffer_by_tag_type(TAG_TYPE_PARADOX);
+    memcpy(buffer->buffer, data, LF_PARADOX_TAG_ID_SIZE);
+    tag_emulation_load_by_buffer(TAG_TYPE_PARADOX, false);
+    return data_frame_make(cmd, STATUS_SUCCESS, 0, NULL);
+}
+
+static data_frame_tx_t *cmd_processor_paradox_get_emu_id(uint16_t cmd, uint16_t status, uint16_t length, uint8_t *data) {
+    tag_slot_specific_type_t tag_types;
+    tag_emulation_get_specific_types_by_slot(tag_emulation_get_slot(), &tag_types);
+    if (tag_types.tag_lf != TAG_TYPE_PARADOX) {
+        return data_frame_make(cmd, STATUS_PAR_ERR, 0, data);
+    }
+    tag_data_buffer_t *buffer = get_buffer_by_tag_type(TAG_TYPE_PARADOX);
+    return data_frame_make(cmd, STATUS_SUCCESS, LF_PARADOX_TAG_ID_SIZE, buffer->buffer);
 }
 
 static data_frame_tx_t *cmd_processor_idteck_set_emu_id(uint16_t cmd, uint16_t status, uint16_t length, uint8_t *data) {
@@ -3125,6 +3163,8 @@ static cmd_data_map_t m_data_cmd_map[] = {
     {    DATA_CMD_VIKING_SCAN,                  before_reader_run,           cmd_processor_viking_scan,                   NULL                   },
     {    DATA_CMD_VIKING_WRITE_TO_T55XX,        before_reader_run,           cmd_processor_viking_write_to_t55xx,         NULL                   },
     {    DATA_CMD_IOPROX_SCAN,                  before_reader_run,           cmd_processor_ioprox_scan,                   NULL                   },
+    {    DATA_CMD_PARADOX_SCAN,                 before_reader_run,           cmd_processor_paradox_scan,                  NULL                   },
+    {    DATA_CMD_PARADOX_GET_LAST_DEMOD,       NULL,                        cmd_processor_paradox_get_last_demod,         NULL                   },
     {    DATA_CMD_IOPROX_WRITE_TO_T55XX,        before_reader_run,           cmd_processor_ioprox_write_to_t55xx,         NULL                   },
     {    DATA_CMD_PAC_SCAN,                     before_reader_run,           cmd_processor_pac_scan,                      NULL                   },
     {    DATA_CMD_PAC_WRITE_TO_T55XX,           before_reader_run,           cmd_processor_pac_write_to_t55xx,            NULL                   },
@@ -3198,6 +3238,8 @@ static cmd_data_map_t m_data_cmd_map[] = {
     {    DATA_CMD_HIDPROX_GET_EMU_ID,             NULL,                      cmd_processor_hidprox_get_emu_id,            NULL                   },
     {    DATA_CMD_IOPROX_SET_EMU_ID,              NULL,                      cmd_processor_ioprox_set_emu_id,             NULL                   },
     {    DATA_CMD_IOPROX_GET_EMU_ID,              NULL,                      cmd_processor_ioprox_get_emu_id,             NULL                   },
+    {    DATA_CMD_PARADOX_SET_EMU_ID,             NULL,                      cmd_processor_paradox_set_emu_id,            NULL                   },
+    {    DATA_CMD_PARADOX_GET_EMU_ID,             NULL,                      cmd_processor_paradox_get_emu_id,            NULL                   },
     {    DATA_CMD_VIKING_SET_EMU_ID,              NULL,                      cmd_processor_viking_set_emu_id,             NULL                   },
     {    DATA_CMD_VIKING_GET_EMU_ID,              NULL,                      cmd_processor_viking_get_emu_id,             NULL                   },
     {    DATA_CMD_PAC_SET_EMU_ID,                 NULL,                      cmd_processor_pac_set_emu_id,                NULL                   },

--- a/firmware/application/src/data_cmd.h
+++ b/firmware/application/src/data_cmd.h
@@ -202,9 +202,13 @@
 #define DATA_CMD_JABLOTRON_GET_EMU_ID           (5011)
 #define DATA_CMD_IDTECK_SET_EMU_ID              (5012)
 #define DATA_CMD_IDTECK_GET_EMU_ID              (5013)
+#define DATA_CMD_PARADOX_SET_EMU_ID             (5014)
+#define DATA_CMD_PARADOX_GET_EMU_ID             (5015)
 
 #define DATA_CMD_EM4X05_SCAN                    (3030)
 #define DATA_CMD_EM4X05_READSNIFF               (3032)
 #define DATA_CMD_LF_SNIFF                       (3031)
+#define DATA_CMD_PARADOX_SCAN                   (3033)
+#define DATA_CMD_PARADOX_GET_LAST_DEMOD         (3034)
 
 #endif

--- a/firmware/application/src/rfid/nfctag/lf/lf_tag_em.c
+++ b/firmware/application/src/rfid/nfctag/lf/lf_tag_em.c
@@ -14,6 +14,7 @@
 #include "protocols/ioprox.h"
 #include "protocols/jablotron.h"
 #include "protocols/pac.h"
+#include "protocols/paradox.h"
 #include "protocols/viking.h"
 #include "syssleep.h"
 #include "tag_emulation.h"
@@ -252,6 +253,15 @@ int lf_tag_data_loadcb(tag_specific_type_t type, tag_data_buffer_t *buffer) {
         return LF_IOPROX_TAG_ID_SIZE;
     }
 
+    if (type == TAG_TYPE_PARADOX && buffer->length >= LF_PARADOX_TAG_ID_SIZE) {
+        m_tag_type = type;
+        void *codec = paradox.alloc();
+        m_pwm_seq = paradox.modulator(codec, buffer->buffer);
+        paradox.free(codec);
+        NRF_LOG_INFO("load lf paradox data finish.");
+        return LF_PARADOX_TAG_ID_SIZE;
+    }
+
     if (type == TAG_TYPE_VIKING && buffer->length >= LF_VIKING_TAG_ID_SIZE) {
         m_tag_type = type;
         void *codec = viking.alloc();
@@ -331,6 +341,10 @@ int lf_tag_ioprox_data_savecb(tag_specific_type_t type, tag_data_buffer_t *buffe
     return m_tag_type == TAG_TYPE_IOPROX ? LF_IOPROX_TAG_ID_SIZE : 0;
 }
 
+int lf_tag_paradox_data_savecb(tag_specific_type_t type, tag_data_buffer_t *buffer) {
+    return m_tag_type == TAG_TYPE_PARADOX ? LF_PARADOX_TAG_ID_SIZE : 0;
+}
+
 /** @brief Id card deposit card number before callback
  * @param type      Refined tag type
  * @param buffer    Data buffer
@@ -398,6 +412,12 @@ bool lf_tag_ioprox_data_factory(uint8_t slot, tag_specific_type_t tag_type) {
     uint8_t tag_id[16] = {
         0x01, 0xAA, 0x30, 0x39, 0x00, 0x78, 0x6A, 0xA0, 0x33, 0x09, 0xCF, 0xEF, 0x00, 0x00, 0x00, 0x00
     };
+    return lf_tag_data_factory(slot, tag_type, tag_id, sizeof(tag_id));
+}
+
+bool lf_tag_paradox_data_factory(uint8_t slot, tag_specific_type_t tag_type) {
+    // Proxmark3's documented sample credential: facility 96, card 40426.
+    uint8_t tag_id[LF_PARADOX_TAG_ID_SIZE] = {0x60, 0x9d, 0xea, 0x00};
     return lf_tag_data_factory(slot, tag_type, tag_id, sizeof(tag_id));
 }
 

--- a/firmware/application/src/rfid/nfctag/lf/lf_tag_em.h
+++ b/firmware/application/src/rfid/nfctag/lf/lf_tag_em.h
@@ -13,6 +13,7 @@
 #define LF_PAC_TAG_ID_SIZE 8
 #define LF_JABLOTRON_TAG_ID_SIZE 5
 #define LF_IDTECK_TAG_ID_SIZE 8
+#define LF_PARADOX_TAG_ID_SIZE 4
 
 void lf_tag_125khz_sense_switch(bool enable);
 int lf_tag_data_loadcb(tag_specific_type_t type, tag_data_buffer_t *buffer);
@@ -22,6 +23,8 @@ int lf_tag_hidprox_data_savecb(tag_specific_type_t type, tag_data_buffer_t *buff
 bool lf_tag_hidprox_data_factory(uint8_t slot, tag_specific_type_t tag_type);
 int lf_tag_ioprox_data_savecb(tag_specific_type_t type, tag_data_buffer_t *buffer);
 bool lf_tag_ioprox_data_factory(uint8_t slot, tag_specific_type_t tag_type);
+int lf_tag_paradox_data_savecb(tag_specific_type_t type, tag_data_buffer_t *buffer);
+bool lf_tag_paradox_data_factory(uint8_t slot, tag_specific_type_t tag_type);
 int lf_tag_viking_data_savecb(tag_specific_type_t type, tag_data_buffer_t *buffer);
 bool lf_tag_viking_data_factory(uint8_t slot, tag_specific_type_t tag_type);
 int lf_tag_pac_data_savecb(tag_specific_type_t type, tag_data_buffer_t *buffer);

--- a/firmware/application/src/rfid/nfctag/lf/protocols/paradox.c
+++ b/firmware/application/src/rfid/nfctag/lf/protocols/paradox.c
@@ -1,0 +1,248 @@
+#include "paradox.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+#include "nrf_pwm.h"
+#include "tag_base_type.h"
+#include "utils/fskdemod.h"
+
+// Paradox is FSK2a, RF/50, with 96 on-air bits. The first eight bits are the
+// unencoded 00001111 preamble; the remaining 88 bits contain Manchester data.
+#define PARADOX_FRAME_BITS 96
+
+// These timings match the established HID Prox FSK2a carrier pair. With the
+// 125 kHz PWM base clock they produce 10 carrier cycles in 50 ticks and 8
+// carrier cycles in 48 ticks, respectively.
+#define PARADOX_PWM_LO_FREQ_LOOP 5
+#define PARADOX_PWM_LO_FREQ_TOP_VALUE 10
+#define PARADOX_PWM_HI_FREQ_LOOP 6
+#define PARADOX_PWM_HI_FREQ_TOP_VALUE 8
+
+typedef struct {
+    fsk_t *modem;
+    uint8_t bits[PARADOX_FRAME_BITS * 2];
+    uint16_t bit_length;
+    uint8_t data[PARADOX_DATA_SIZE];
+} paradox_codec_t;
+
+static nrf_pwm_values_wave_form_t
+    m_paradox_pwm_seq_vals[PARADOX_FRAME_BITS * PARADOX_PWM_HI_FREQ_LOOP] = {};
+
+static nrf_pwm_sequence_t m_paradox_pwm_seq = {
+    .values.p_wave_form = m_paradox_pwm_seq_vals,
+    .length = NRF_PWM_VALUES_LENGTH(m_paradox_pwm_seq_vals),
+    .repeats = 0,
+    .end_delay = 0,
+};
+
+// Encode 16 input bits MSB-first using IEEE Manchester: 0 -> 01, 1 -> 10.
+static uint32_t manchester_encode_u16(uint16_t value) {
+    uint32_t encoded = 0;
+    for (uint8_t i = 0; i < 16; i++) {
+        encoded <<= 2;
+        encoded |= (value & (uint16_t)(0x8000u >> i)) ? 0x02u : 0x01u;
+    }
+    return encoded;
+}
+
+// CRC-8/MAXIM-DOW: poly=0x31 (reflected 0x8c), init=0, refin/refout=true.
+static uint8_t crc8_maxim(const uint8_t *data, size_t length) {
+    uint8_t crc = 0;
+    for (size_t i = 0; i < length; i++) {
+        crc ^= data[i];
+        for (uint8_t bit = 0; bit < 8; bit++) {
+            crc = (crc & 1u) ? (uint8_t)((crc >> 1) ^ 0x8cu)
+                             : (uint8_t)(crc >> 1);
+        }
+    }
+    return crc;
+}
+
+bool paradox_encode_raw(uint8_t facility_code, uint16_t card_number,
+                        uint8_t raw[PARADOX_RAW_SIZE]) {
+    if (raw == NULL) {
+        return false;
+    }
+
+    // One extra byte is required while the Manchester stream is shifted left
+    // by four bits after the checksum has been calculated.
+    uint8_t frame[PARADOX_RAW_SIZE + 1] = {0};
+    frame[0] = 0x0f;
+    frame[1] = 0x05;
+    frame[2] = 0x55;
+    frame[3] = 0x55;
+
+    uint32_t encoded = manchester_encode_u16(facility_code);
+    frame[4] = (uint8_t)(encoded >> 8);
+    frame[5] = (uint8_t)encoded;
+
+    encoded = manchester_encode_u16(card_number);
+    frame[6] = (uint8_t)(encoded >> 24);
+    frame[7] = (uint8_t)(encoded >> 16);
+    frame[8] = (uint8_t)(encoded >> 8);
+    frame[9] = (uint8_t)encoded;
+
+    const uint8_t checksum = (uint8_t)(crc8_maxim(frame + 1, 9) ^ 0x06u);
+    encoded = manchester_encode_u16(checksum);
+    frame[10] = (uint8_t)(encoded >> 8);
+    frame[11] = (uint8_t)encoded;
+
+    // The data following the preamble begins four bits into frame[1]. Align it
+    // to the transmitted byte stream and append the terminal 1010 pattern.
+    for (uint8_t i = 1; i < PARADOX_RAW_SIZE; i++) {
+        frame[i] = (uint8_t)((frame[i] << 4) | (frame[i + 1] >> 4));
+    }
+    frame[PARADOX_RAW_SIZE - 1] |= 0x0au;
+
+    memcpy(raw, frame, PARADOX_RAW_SIZE);
+    return true;
+}
+
+static void *paradox_codec_alloc(void) {
+    paradox_codec_t *codec = calloc(1, sizeof(paradox_codec_t));
+    if (codec != NULL) {
+        codec->modem = fsk_alloc(FSK_BITRATE_HID);
+        if (codec->modem == NULL) {
+            free(codec);
+            return NULL;
+        }
+    }
+    return codec;
+}
+
+static void paradox_codec_free(void *codec) {
+    paradox_codec_t *paradox_codec = codec;
+    if (paradox_codec != NULL) {
+        fsk_free(paradox_codec->modem);
+        free(paradox_codec);
+    }
+}
+
+static uint8_t *paradox_get_data(void *codec) {
+    return ((paradox_codec_t *)codec)->data;
+}
+
+static void paradox_decoder_start(void *codec, uint8_t format_hint) {
+    (void)format_hint;
+    paradox_codec_t *paradox_codec = codec;
+    paradox_codec->bit_length = 0;
+    paradox_codec->modem->c = 0;
+    memset(paradox_codec->modem->samples, 0,
+           sizeof(paradox_codec->modem->samples));
+    memset(paradox_codec->bits, 0, sizeof(paradox_codec->bits));
+    memset(paradox_codec->data, 0, sizeof(paradox_codec->data));
+}
+
+static bool paradox_decode_frame(paradox_codec_t *codec, uint16_t offset,
+                                 bool inverted) {
+    uint8_t raw[PARADOX_RAW_SIZE] = {0};
+    for (uint16_t i = 0; i < PARADOX_FRAME_BITS; i++) {
+        uint8_t bit = codec->bits[offset + i] ^ (inverted ? 1u : 0u);
+        raw[i / 8] |= (uint8_t)(bit << (7 - (i % 8)));
+    }
+    if (raw[0] != 0x0f) {
+        return false;
+    }
+
+    uint64_t decoded = 0;
+    for (uint16_t i = 8; i < PARADOX_FRAME_BITS; i += 2) {
+        uint8_t first = (raw[i / 8] >> (7 - (i % 8))) & 1u;
+        uint8_t second = (raw[(i + 1) / 8] >> (7 - ((i + 1) % 8))) & 1u;
+        if (first == second) {
+            return false;
+        }
+        decoded = (decoded << 1) | (first && !second ? 1u : 0u);
+    }
+
+    // The Manchester payload is 10 zero bits, FC, CN, CRC, then two one bits.
+    if ((decoded >> 34) != 0 || (decoded & 0x03u) != 0x03u) {
+        return false;
+    }
+    uint8_t facility_code = (uint8_t)(decoded >> 26);
+    uint16_t card_number = (uint16_t)(decoded >> 10);
+
+    uint8_t expected[PARADOX_RAW_SIZE];
+    paradox_encode_raw(facility_code, card_number, expected);
+    if (memcmp(raw, expected, sizeof(raw)) != 0) {
+        return false;
+    }
+
+    codec->data[0] = facility_code;
+    codec->data[1] = (uint8_t)(card_number >> 8);
+    codec->data[2] = (uint8_t)card_number;
+    codec->data[3] = 0;
+    return true;
+}
+
+static bool paradox_decoder_feed(void *codec, uint16_t value) {
+    paradox_codec_t *paradox_codec = codec;
+    if (paradox_codec == NULL || paradox_codec->modem == NULL) {
+        return false;
+    }
+
+    bool bit;
+    if (!fsk_feed(paradox_codec->modem, value, &bit)) {
+        return false;
+    }
+
+    if (paradox_codec->bit_length == sizeof(paradox_codec->bits)) {
+        memmove(paradox_codec->bits, paradox_codec->bits + PARADOX_FRAME_BITS,
+                sizeof(paradox_codec->bits) - PARADOX_FRAME_BITS);
+        paradox_codec->bit_length -= PARADOX_FRAME_BITS;
+    }
+    paradox_codec->bits[paradox_codec->bit_length++] = bit ? 1u : 0u;
+
+    if (paradox_codec->bit_length < PARADOX_FRAME_BITS) {
+        return false;
+    }
+    uint16_t offset = paradox_codec->bit_length - PARADOX_FRAME_BITS;
+    return paradox_decode_frame(paradox_codec, offset, false) ||
+           paradox_decode_frame(paradox_codec, offset, true);
+}
+
+static inline void paradox_emit_bit(uint16_t *index, bool bit) {
+    if (!bit) {
+        for (uint8_t i = 0; i < PARADOX_PWM_HI_FREQ_LOOP; i++) {
+            m_paradox_pwm_seq_vals[*index].channel_0 = PARADOX_PWM_HI_FREQ_TOP_VALUE / 2;
+            m_paradox_pwm_seq_vals[*index].counter_top = PARADOX_PWM_HI_FREQ_TOP_VALUE;
+            (*index)++;
+        }
+    } else {
+        for (uint8_t i = 0; i < PARADOX_PWM_LO_FREQ_LOOP; i++) {
+            m_paradox_pwm_seq_vals[*index].channel_0 = PARADOX_PWM_LO_FREQ_TOP_VALUE / 2;
+            m_paradox_pwm_seq_vals[*index].counter_top = PARADOX_PWM_LO_FREQ_TOP_VALUE;
+            (*index)++;
+        }
+    }
+}
+
+static nrf_pwm_sequence_t *paradox_modulator(void *codec, uint8_t *buffer) {
+    (void)codec;
+
+    uint8_t raw[PARADOX_RAW_SIZE];
+    paradox_encode_raw(buffer[0], (uint16_t)(((uint16_t)buffer[1] << 8) | buffer[2]), raw);
+
+    uint16_t index = 0;
+    for (uint8_t byte = 0; byte < PARADOX_RAW_SIZE; byte++) {
+        for (int8_t bit = 7; bit >= 0; bit--) {
+            paradox_emit_bit(&index, ((raw[byte] >> bit) & 1u) != 0);
+        }
+    }
+
+    m_paradox_pwm_seq.length = (uint16_t)(index * 4u);
+    return &m_paradox_pwm_seq;
+}
+
+const protocol paradox = {
+    .tag_type = TAG_TYPE_PARADOX,
+    .data_size = PARADOX_DATA_SIZE,
+    .alloc = paradox_codec_alloc,
+    .free = paradox_codec_free,
+    .get_data = paradox_get_data,
+    .decoder = {
+        .start = paradox_decoder_start,
+        .feed = paradox_decoder_feed,
+    },
+    .modulator = paradox_modulator,
+};

--- a/firmware/application/src/rfid/nfctag/lf/protocols/paradox.h
+++ b/firmware/application/src/rfid/nfctag/lf/protocols/paradox.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "protocols.h"
+
+// Stored emulator payload (word-aligned):
+//   0:   facility code
+//   1-2: card number (big-endian)
+//   3:   reserved
+#define PARADOX_DATA_SIZE 4
+#define PARADOX_RAW_SIZE 12
+
+extern const protocol paradox;
+
+// Encode a Paradox credential into the complete 96-bit FSK2a on-air frame.
+bool paradox_encode_raw(uint8_t facility_code, uint16_t card_number,
+                        uint8_t raw[PARADOX_RAW_SIZE]);

--- a/firmware/application/src/rfid/nfctag/lf/utils/fskdemod.c
+++ b/firmware/application/src/rfid/nfctag/lf/utils/fskdemod.c
@@ -7,11 +7,12 @@
 #define PI 3.14159265358979f
 #define GOERTZEL(FREQ, SAMPLE_RATE) (2.0 * cos((2.0 * PI * FREQ) / (SAMPLE_RATE)))
 
-static float goertzel_power(float coef, const uint16_t samples[], int n) {
+static float goertzel_power(float coef, const uint16_t samples[], int n,
+                            float mean) {
     float z1 = 0;
     float z2 = 0;
     for (int i = 0; i < n; i++) {
-        float z0 = coef * z1 - z2 + (float)(samples[i]);
+        float z0 = coef * z1 - z2 + ((float)samples[i] - mean);
         z2 = z1;
         z1 = z0;
     }
@@ -37,8 +38,13 @@ bool fsk_feed(fsk_t *m, uint16_t sample, bool *bit) {
     if (m->c < m->bitrate) {
         return false;
     }
-    float bit0 = goertzel_power(m->goertzel_fc_8,  m->samples, m->bitrate);
-    float bit1 = goertzel_power(m->goertzel_fc_10, m->samples, m->bitrate);
+    uint32_t sample_sum = 0;
+    for (uint8_t i = 0; i < m->bitrate; i++) {
+        sample_sum += m->samples[i];
+    }
+    float mean = (float)sample_sum / m->bitrate;
+    float bit0 = goertzel_power(m->goertzel_fc_8, m->samples, m->bitrate, mean);
+    float bit1 = goertzel_power(m->goertzel_fc_10, m->samples, m->bitrate, mean);
     *bit = (bit1 > bit0);
 
     // Reset counter and clear sample buffer for the next bit

--- a/firmware/application/src/rfid/nfctag/tag_base_type.h
+++ b/firmware/application/src/rfid/nfctag/tag_base_type.h
@@ -55,8 +55,8 @@ typedef enum {
     //////// FSK Tag-Talk-First   200
     TAG_TYPE_HID_PROX = 200,
     TAG_TYPE_IOPROX,
-    // AWID
-    // Paradox
+    // 202 is reserved for AWID.
+    TAG_TYPE_PARADOX = 203,
 
     //////// PSK Tag-Talk-First   300
     // Indala
@@ -112,7 +112,7 @@ typedef enum {
     }
 
 #define TAG_SPECIFIC_TYPE_LF_VALUES \
-    TAG_TYPE_EM410X, TAG_TYPE_EM410X_ELECTRA, TAG_TYPE_PAC, TAG_TYPE_HID_PROX, TAG_TYPE_IOPROX, TAG_TYPE_VIKING, TAG_TYPE_JABLOTRON, TAG_TYPE_IDTECK
+    TAG_TYPE_EM410X, TAG_TYPE_EM410X_ELECTRA, TAG_TYPE_PAC, TAG_TYPE_HID_PROX, TAG_TYPE_IOPROX, TAG_TYPE_PARADOX, TAG_TYPE_VIKING, TAG_TYPE_JABLOTRON, TAG_TYPE_IDTECK
 
 // Tag types that use PSK1 modulation for emulation. These require the PWM
 // base clock to be set to 1MHz (see lf_tag_em.c pwm_init) so the 16us

--- a/firmware/application/src/rfid/nfctag/tag_emulation.c
+++ b/firmware/application/src/rfid/nfctag/tag_emulation.c
@@ -95,6 +95,7 @@ static tag_base_handler_map_t tag_base_map[] = {
     {TAG_SENSE_LF, TAG_TYPE_EM410X_ELECTRA, lf_tag_data_loadcb,        lf_tag_em410x_data_savecb,    lf_tag_em410x_data_factory,    &m_tag_data_lf},
     {TAG_SENSE_LF, TAG_TYPE_HID_PROX,    lf_tag_data_loadcb,           lf_tag_hidprox_data_savecb,   lf_tag_hidprox_data_factory,   &m_tag_data_lf},
     {TAG_SENSE_LF, TAG_TYPE_IOPROX,      lf_tag_data_loadcb,           lf_tag_ioprox_data_savecb,    lf_tag_ioprox_data_factory,    &m_tag_data_lf},
+    {TAG_SENSE_LF, TAG_TYPE_PARADOX,     lf_tag_data_loadcb,           lf_tag_paradox_data_savecb,   lf_tag_paradox_data_factory,   &m_tag_data_lf},
     {TAG_SENSE_LF, TAG_TYPE_VIKING,      lf_tag_data_loadcb,           lf_tag_viking_data_savecb,    lf_tag_viking_data_factory,    &m_tag_data_lf},
     {TAG_SENSE_LF, TAG_TYPE_PAC,         lf_tag_data_loadcb,           lf_tag_pac_data_savecb,       lf_tag_pac_data_factory,       &m_tag_data_lf},
     {TAG_SENSE_LF, TAG_TYPE_JABLOTRON,   lf_tag_data_loadcb,           lf_tag_jablotron_data_savecb, lf_tag_jablotron_data_factory, &m_tag_data_lf},

--- a/firmware/application/src/rfid/reader/lf/lf_paradox_data.c
+++ b/firmware/application/src/rfid/reader/lf/lf_paradox_data.c
@@ -1,0 +1,133 @@
+#include <string.h>
+
+#include "bsp_delay.h"
+#include "bsp_time.h"
+#include "bsp_wdt.h"
+#include "circular_buffer.h"
+#include "lf_125khz_radio.h"
+#include "lf_reader_data.h"
+#include "protocols/paradox.h"
+#include "utils/fskdemod.h"
+
+#define PARADOX_BUFFER_SIZE 6144
+#define PARADOX_SAMPLE_BUFFER_SIZE 10000
+
+static circular_buffer cb;
+static volatile bool sampling;
+static uint16_t sample_buffer[PARADOX_SAMPLE_BUFFER_SIZE];
+static uint8_t last_demod[29];
+static size_t last_demod_length;
+
+static void saadc_cb(nrf_saadc_value_t *values, size_t size) {
+    if (!sampling) {
+        return;
+    }
+    for (size_t i = 0; i < size && sampling; i++) {
+        uint16_t value = (uint16_t)values[i];
+        cb_push_back(&cb, &value);
+    }
+}
+
+static void save_best_demodulation(size_t sample_count) {
+    uint8_t best_errors = UINT8_MAX;
+    last_demod_length = 0;
+
+    for (uint8_t phase = 0; phase < FSK_BITRATE_HID; phase++) {
+        fsk_t *modem = fsk_alloc(FSK_BITRATE_HID);
+        if (modem == NULL) {
+            return;
+        }
+
+        uint8_t bits[200] = {0};
+        uint8_t bit_count = 0;
+        for (size_t i = phase; i < sample_count && bit_count < sizeof(bits); i++) {
+            bool bit;
+            if (fsk_feed(modem, sample_buffer[i], &bit)) {
+                bits[bit_count++] = bit ? 1u : 0u;
+            }
+        }
+        fsk_free(modem);
+
+        for (uint8_t pairing = 0; pairing < 2; pairing++) {
+            uint8_t errors = 0;
+            for (uint8_t i = pairing; (uint16_t)i + 1u < bit_count; i += 2) {
+                errors += bits[i] == bits[i + 1];
+            }
+            if (errors >= best_errors) {
+                continue;
+            }
+
+            best_errors = errors;
+            memset(last_demod, 0, sizeof(last_demod));
+            last_demod[0] = phase;
+            last_demod[1] = pairing;
+            last_demod[2] = errors;
+            last_demod[3] = bit_count;
+            for (uint8_t i = 0; i < bit_count; i++) {
+                last_demod[4 + i / 8] |= (uint8_t)(bits[i] << (7 - (i % 8)));
+            }
+            last_demod_length = 4 + (bit_count + 7) / 8;
+        }
+        bsp_wdt_feed();
+    }
+}
+
+size_t paradox_get_last_demod(uint8_t *data, size_t maximum) {
+    size_t length = last_demod_length < maximum ? last_demod_length : maximum;
+    memcpy(data, last_demod, length);
+    return length;
+}
+
+bool paradox_read(uint8_t *data, uint32_t timeout_ms) {
+    void *codec = paradox.alloc();
+    if (codec == NULL) {
+        return false;
+    }
+    paradox.decoder.start(codec, 0);
+
+    cb_init(&cb, PARADOX_BUFFER_SIZE, sizeof(uint16_t));
+    stop_lf_125khz_radio();
+    lf_125khz_radio_saadc_disable();
+    bsp_delay_ms(50);
+
+    sampling = true;
+    start_lf_125khz_radio();
+    bsp_delay_ms(10);
+    lf_125khz_radio_saadc_enable(saadc_cb);
+
+    size_t sample_count = 0;
+    autotimer *timer = bsp_obtain_timer(0);
+    while (sample_count < PARADOX_SAMPLE_BUFFER_SIZE &&
+           NO_TIMEOUT_1MS(timer, timeout_ms)) {
+        uint16_t value;
+        while (sample_count < PARADOX_SAMPLE_BUFFER_SIZE &&
+               cb_pop_front(&cb, &value)) {
+            sample_buffer[sample_count++] = value;
+        }
+        bsp_wdt_feed();
+    }
+
+    bsp_return_timer(timer);
+    sampling = false;
+    stop_lf_125khz_radio();
+    lf_125khz_radio_saadc_disable();
+    cb_free(&cb);
+
+    save_best_demodulation(sample_count);
+
+    bool found = false;
+    for (uint8_t phase = 0; phase < FSK_BITRATE_HID && !found; phase++) {
+        paradox.decoder.start(codec, 0);
+        for (size_t i = phase; i < sample_count; i++) {
+            if (paradox.decoder.feed(codec, sample_buffer[i])) {
+                memcpy(data, paradox.get_data(codec), paradox.data_size);
+                found = true;
+                break;
+            }
+        }
+        bsp_wdt_feed();
+    }
+
+    paradox.free(codec);
+    return found;
+}

--- a/firmware/application/src/rfid/reader/lf/lf_reader_data.h
+++ b/firmware/application/src/rfid/reader/lf/lf_reader_data.h
@@ -20,6 +20,8 @@ void clear_lf_counter_value(void);
 
 bool em410x_read(uint8_t *data, uint32_t timeout_ms);
 bool ioprox_read(uint8_t *data, uint8_t format_hint, uint32_t timeout_ms);
+bool paradox_read(uint8_t *data, uint32_t timeout_ms);
+size_t paradox_get_last_demod(uint8_t *data, size_t maximum);
 bool hidprox_read(uint8_t *data, uint8_t format_hint, uint32_t timeout_ms);
 bool pac_read(uint8_t *data, uint32_t timeout_ms);
 bool viking_read(uint8_t *data, uint32_t timeout_ms);

--- a/firmware/application/src/rfid/reader/lf/lf_reader_main.c
+++ b/firmware/application/src/rfid/reader/lf/lf_reader_main.c
@@ -56,6 +56,13 @@ uint8_t scan_ioprox(uint8_t *data, uint8_t format_hint) {
     return STATUS_LF_TAG_NO_FOUND;
 }
 
+uint8_t scan_paradox(uint8_t *data) {
+    if (paradox_read(data, g_timeout_readem_ms)) {
+        return STATUS_LF_TAG_OK;
+    }
+    return STATUS_LF_TAG_NO_FOUND;
+}
+
 /**
  * @brief Decode raw8 data to structured ioProx format
  * @param raw8 Input 8 bytes

--- a/firmware/application/src/rfid/reader/lf/lf_reader_main.h
+++ b/firmware/application/src/rfid/reader/lf/lf_reader_main.h
@@ -13,6 +13,7 @@
 void set_scan_tag_timeout(uint32_t ms);
 uint8_t scan_em410x(uint8_t *uid);
 uint8_t scan_ioprox(uint8_t *uid, uint8_t format_hint);
+uint8_t scan_paradox(uint8_t *data);
 uint8_t decode_ioprox_raw(uint8_t *raw8, uint8_t *output);
 uint8_t encode_ioprox_params(uint8_t ver, uint8_t fc, uint16_t cn, uint8_t *out);
 uint8_t scan_hidprox(uint8_t *uid, uint8_t format_hint);

--- a/software/script/chameleon_cli_unit.py
+++ b/software/script/chameleon_cli_unit.py
@@ -17,7 +17,6 @@ import queue
 from enum import Enum
 from multiprocessing import Pool, cpu_count
 from typing import Union
-from pathlib import Path
 from platform import uname
 from datetime import datetime
 import hardnested_utils
@@ -5930,7 +5929,7 @@ class LFIOProxRead(LFIOProxReadArgsUnit, ReaderRequiredUnit):
 
     def on_exec(self, args: argparse.Namespace):
         ver, fc, cn, raw8, *futureuse = self.cmd.ioprox_scan()
-        print(f"ioProx XSF format")
+        print("ioProx XSF format")
         print(f"   Version: {color_string((CG, ver))}")
         print(f"   Facility: {color_string((CG, f'{fc} [0x{fc:02X}]'))}")
         print(f"   ID: {color_string((CY, cn))}")
@@ -5965,9 +5964,9 @@ class LFIOProxWriteT55xx(LFIOProxIdArgsUnit, ReaderRequiredUnit):
             cn & 0xFFFF,
             raw8
         )
-        result = self.cmd.ioprox_write_to_t55xx(payload16)
+        self.cmd.ioprox_write_to_t55xx(payload16)
 
-        print(f"ioProx XSF format")
+        print("ioProx XSF format")
         print(f"   Version: {color_string((CG, ver))}")
         print(f"   Facility: {color_string((CG, f'{fc} [0x{fc:02X}]'))}")
         print(f"   ID: {color_string((CY, cn))}")
@@ -6016,9 +6015,9 @@ class LFIOProxEconfig(SlotIndexArgsAndGoUnit, LFIOProxIdArgsUnit):
                 raw8
             )
 
-            result = self.cmd.ioprox_set_emu_id(payload16)
+            self.cmd.ioprox_set_emu_id(payload16)
 
-            print(f"ioProx XSF format")
+            print("ioProx XSF format")
             print(f"   Version: {color_string((CG, ver))}")
             print(f"   Facility: {color_string((CG, f'{fc} [0x{fc:02X}]'))}")
             print(f"   ID: {color_string((CY, cn))}")
@@ -6027,7 +6026,7 @@ class LFIOProxEconfig(SlotIndexArgsAndGoUnit, LFIOProxIdArgsUnit):
         else:
             # GET
             ver, fc, cn, raw8, *futureuse = self.cmd.ioprox_get_emu_id()
-            print(f"ioProx XSF format")
+            print("ioProx XSF format")
             print(f"   Version: {color_string((CG, ver))}")
             print(f"   Facility: {color_string((CG, f'{fc} [0x{fc:02X}]'))}")
             print(f"   ID: {color_string((CY, cn))}")
@@ -6467,7 +6466,7 @@ class LFT55xxClone(ReaderRequiredUnit):
     def on_exec(self, args: argparse.Namespace):
         # Clone requires LF writer — only available on Chameleon Ultra (not Lite)
         if self.cmd.get_device_model() != 0:
-            print(f" - Error: LF clone requires Chameleon Ultra. Lite has no LF writer.")
+            print(" - Error: LF clone requires Chameleon Ultra. Lite has no LF writer.")
             return
         t = args.type
 
@@ -6505,7 +6504,7 @@ class LFT55xxClone(ReaderRequiredUnit):
                 oem,
             )
             self.cmd.hidprox_write_to_t55xx(id_bytes)
-            print(f" - HID Prox cloned to T55xx")
+            print(" - HID Prox cloned to T55xx")
             print(f"   Format : {fmt.name}")
             if fc:
                 print(f"   FC     : {fc}")
@@ -6527,7 +6526,7 @@ class LFT55xxClone(ReaderRequiredUnit):
                 raw8 = res[3]
             payload16 = struct.pack(">BBH8s4x", ver & 0xFF, fc & 0xFF, cn & 0xFFFF, raw8)
             self.cmd.ioprox_write_to_t55xx(payload16)
-            print(f" - ioProx cloned to T55xx")
+            print(" - ioProx cloned to T55xx")
             print(f"   Ver    : {ver}")
             print(f"   FC     : {fc} [0x{fc:02X}]")
             print(f"   CN     : {cn}")
@@ -7559,7 +7558,7 @@ class HWRaw(DeviceRequiredUnit):
         if response.data:
             print(f"   Data (HEX): {response.data.hex()}")
         else:
-            print(f"   Data (HEX): (none)")
+            print("   Data (HEX): (none)")
 
 
 @hf_14a.command("raw")
@@ -8807,9 +8806,6 @@ class DataPlot(BaseCLIUnit):
         if not args.ascii:
             # Try PyQt5 first, then matplotlib
             try:
-                from PyQt5.QtWidgets import QApplication, QMainWindow, QVBoxLayout, QWidget
-                from PyQt5.QtCore import Qt
-                import pyqtgraph as pg
                 _plot_pyqtgraph(xs, view, mean, threshold, start, end)
                 return
             except ImportError:
@@ -8817,13 +8813,11 @@ class DataPlot(BaseCLIUnit):
             try:
                 import matplotlib
                 matplotlib.use('Qt5Agg')
-                import matplotlib.pyplot as plt
                 _plot_matplotlib(xs, view, mean, threshold, start, end)
                 return
             except ImportError:
                 pass
             try:
-                import matplotlib.pyplot as plt
                 _plot_matplotlib(xs, view, mean, threshold, start, end)
                 return
             except ImportError:
@@ -8902,9 +8896,7 @@ def _plot_matplotlib(xs, ys, mean, threshold, start, end):
 
 def _plot_pyqtgraph(xs, ys, mean, threshold, start, end):
     import sys
-    from PyQt5.QtWidgets import QApplication, QMainWindow, QVBoxLayout, QWidget, QLabel
-    from PyQt5.QtCore import Qt
-    from PyQt5.QtGui import QFont
+    from PyQt5.QtWidgets import QApplication
     import pyqtgraph as pg
 
     pg.setConfigOption('background', '#0d1117')
@@ -9094,10 +9086,6 @@ class DataModulation(BaseCLIUnit):
         if len(runs) < 4:
             print(f" Modulation: {CR}insufficient transitions{C0}")
             return
-
-        runs_sorted = sorted(runs)
-        # Remove outliers (top/bottom 10%)
-        trim = max(1, len(runs) // 10)
 
         # Estimate clock: most common run length = half-period
         from collections import Counter
@@ -9476,7 +9464,7 @@ class EMVScan(DeviceRequiredUnit):
         tags[0x9F12] = app_tags[0x9F12]
         tags[0x50] = app_tags[0x50]
 
-        print(f'')
+        print('')
         print(f' {CG}── Card Details ──────────────────────{C0}')
 
         # App label — show first unique label only
@@ -9761,32 +9749,32 @@ class EMVLoad(DeviceRequiredUnit):
 
         try:
             v = data['PPSE']['FCITemplate']['value'].replace(' ', '')
-            l = data['PPSE']['FCITemplate']['length']
+            length = data['PPSE']['FCITemplate']['length']
             static_pairs.append((
                 bytes.fromhex('00a404000e325041592e5359532e4444463031'),
-                tlv_resp('6F', l, v),
+                tlv_resp('6F', length, v),
                 'SELECT PPSE'))
         except Exception as e:
             print(f' {CR}PPSE: {e}{C0}')
 
         try:
             v = data['Application']['FCITemplate']['value'].replace(' ', '')
-            l = data['Application']['FCITemplate']['length']
+            length = data['Application']['FCITemplate']['length']
             aid = data['Application']['AID'].replace(' ', '')
             static_pairs.append((
                 bytes.fromhex('00a4040007' + aid),
-                tlv_resp('6F', l, v),
+                tlv_resp('6F', length, v),
                 'SELECT AID'))
         except Exception as e:
             print(f' {CR}Application FCI: {e}{C0}')
 
         try:
             v = data['Application']['GPO']['value'].replace(' ', '')
-            l = data['Application']['GPO']['length']
+            length = data['Application']['GPO']['length']
             tag = data['Application']['GPO'].get('tag', '77')
             static_pairs.append((
                 bytes.fromhex('80a80000'),
-                tlv_resp(tag, l, v),
+                tlv_resp(tag, length, v),
                 'GPO'))
         except Exception as e:
             print(f' {CR}GPO: {e}{C0}')
@@ -9796,12 +9784,12 @@ class EMVLoad(DeviceRequiredUnit):
                 sfi_n = int(rec['SFI'], 16)
                 rec_n = int(rec['RecordNum'], 16)
                 v = rec['Data']['value'].replace(' ', '')
-                l = rec['Data']['length']
+                length = rec['Data']['length']
                 tag = rec['Data'].get('tag', '70')
                 p2 = (sfi_n << 3) | 4
                 static_pairs.append((
                     bytes([0x00, 0xB2, rec_n, p2, 0x00]),
-                    tlv_resp(tag, l, v),
+                    tlv_resp(tag, length, v),
                     f'READ RECORD SFI={sfi_n} rec={rec_n}'))
         except Exception as e:
             print(f' {CR}Records: {e}{C0}')
@@ -9857,7 +9845,7 @@ class EMVApdu(DeviceRequiredUnit):
         timeout_ms = max(1000, min(60000, args.timeout))
 
         print(f' {CY}ISO14443-4 T=CL APDU relay started{C0}')
-        print(f' Waiting for a reader to connect (SAK=20 slot required)...')
+        print(' Waiting for a reader to connect (SAK=20 slot required)...')
         print(f' Type {CY}quit{C0} to exit, or enter hex response bytes when prompted.')
 
         exchange_count = 0
@@ -10201,41 +10189,61 @@ def _desfire_get_version(cmd) -> dict:
     info: dict = {}
     hw = resp[:-1]
     # HW frame — individual guards so a short frame still populates what it has
-    if len(hw) >= 1: info['hw_vendor']  = hw[0]
-    if len(hw) >= 2: info['hw_type']    = hw[1]
-    if len(hw) >= 3: info['hw_subtype'] = hw[2]
-    if len(hw) >= 4: info['hw_major']   = hw[3]
-    if len(hw) >= 5: info['hw_minor']   = hw[4]
-    if len(hw) >= 6: info['hw_storage'] = hw[5]
-    if len(hw) >= 7: info['hw_proto']   = hw[6]
+    if len(hw) >= 1:
+        info['hw_vendor'] = hw[0]
+    if len(hw) >= 2:
+        info['hw_type'] = hw[1]
+    if len(hw) >= 3:
+        info['hw_subtype'] = hw[2]
+    if len(hw) >= 4:
+        info['hw_major'] = hw[3]
+    if len(hw) >= 5:
+        info['hw_minor'] = hw[4]
+    if len(hw) >= 6:
+        info['hw_storage'] = hw[5]
+    if len(hw) >= 7:
+        info['hw_proto'] = hw[6]
 
     if resp[-1] == 0xAF:
         resp2 = _des_transceive(cmd, 0xAF)
         sw = resp2[:-1]
         # SW frame — same per-field guards
-        if len(sw) >= 1: info['sw_vendor']  = sw[0]
-        if len(sw) >= 2: info['sw_type']    = sw[1]
-        if len(sw) >= 3: info['sw_subtype'] = sw[2]
-        if len(sw) >= 4: info['sw_major']   = sw[3]
-        if len(sw) >= 5: info['sw_minor']   = sw[4]
-        if len(sw) >= 6: info['sw_storage'] = sw[5]
-        if len(sw) >= 7: info['sw_proto']   = sw[6]
+        if len(sw) >= 1:
+            info['sw_vendor'] = sw[0]
+        if len(sw) >= 2:
+            info['sw_type'] = sw[1]
+        if len(sw) >= 3:
+            info['sw_subtype'] = sw[2]
+        if len(sw) >= 4:
+            info['sw_major'] = sw[3]
+        if len(sw) >= 5:
+            info['sw_minor'] = sw[4]
+        if len(sw) >= 6:
+            info['sw_storage'] = sw[5]
+        if len(sw) >= 7:
+            info['sw_proto'] = sw[6]
 
         # Fallback: derive SW fields from HW when SW frame payload is empty
         if 'sw_major' not in info and 'hw_major' in info:
             info['sw_major'] = _DESFIRE_HW_MAJOR_TO_SW_MAJOR.get(
                 info['hw_major'], info['hw_major'])
             info['sw_minor'] = 0
-        if 'sw_storage' not in info: info['sw_storage'] = info.get('hw_storage')
-        if 'sw_proto'   not in info: info['sw_proto']   = info.get('hw_proto')
+        if 'sw_storage' not in info:
+            info['sw_storage'] = info.get('hw_storage')
+        if 'sw_proto' not in info:
+            info['sw_proto'] = info.get('hw_proto')
 
         if resp2[-1] == 0xAF:
             resp3 = _des_transceive(cmd, 0xAF)
             p3 = resp3[:-1]
-            if len(p3) >= 7:  info['uid']       = p3[:7].hex().upper()
-            if len(p3) >= 12: info['batch']     = p3[7:12].hex().upper()
-            if len(p3) >= 13: info['prod_week'] = p3[12]
-            if len(p3) >= 14: info['prod_year'] = p3[13]
+            if len(p3) >= 7:
+                info['uid'] = p3[:7].hex().upper()
+            if len(p3) >= 12:
+                info['batch'] = p3[7:12].hex().upper()
+            if len(p3) >= 13:
+                info['prod_week'] = p3[12]
+            if len(p3) >= 14:
+                info['prod_year'] = p3[13]
     return info
 
 
@@ -10322,7 +10330,7 @@ class HfDesInfo(ReaderRequiredUnit):
                 for aid in aids:
                     print(f"   AID: {aid.hex().upper()}  ({int.from_bytes(aid, 'little'):06X})")
             else:
-                print(f"\n Applications  : none")
+                print("\n Applications  : none")
         except Exception as e:
             print(f" {CY}[!] GetApplicationIDs failed: {e}{C0}")
 
@@ -10528,8 +10536,7 @@ class HfDesChk(ReaderRequiredUnit):
 
     def on_exec(self, args: argparse.Namespace):
         try:
-            from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
-            from cryptography.hazmat.backends import default_backend
+            import cryptography  # noqa: F401
         except ImportError:
             print(f" {CR}[!] 'cryptography' library required: pip install cryptography{C0}")
             return
@@ -10543,7 +10550,7 @@ class HfDesChk(ReaderRequiredUnit):
         key_no = args.keyno
 
         # Select card and get AID list
-        print(f" Selecting card...")
+        print(" Selecting card...")
         try:
             uid_bytes, sak, _ = _des_select(self.cmd)
         except RuntimeError as e:
@@ -10665,11 +10672,11 @@ class HFSeosELoad(SlotIndexArgsAndGoUnit, HF14AAntiCollArgsUnit, DeviceRequiredU
         parser.add_argument("-d", "--data", type=str, default=None, metavar="<hex>",
                             help="Data to present to reader (2-255 bytes). Must be valid BER-TLV.")
         parser.add_argument("-o", "--oid", type=str, default=None, metavar="<hex>",
-                            help=f"Target OID (1-32 bytes).")
+                            help="Target OID (1-32 bytes).")
         parser.add_argument("-t", "--tag", type=str, default=None, metavar="<hex>",
-                            help=f"Tag of presented data (1-2 bytes).")
+                            help="Tag of presented data (1-2 bytes).")
         parser.add_argument("--diversifier", type=str, default=None, metavar="<hex>",
-                            help=f"Simulated card diversifier (1-16 bytes).")
+                            help="Simulated card diversifier (1-16 bytes).")
         return parser
 
     def on_exec(self, args: argparse.Namespace):
@@ -10686,7 +10693,7 @@ class HFSeosELoad(SlotIndexArgsAndGoUnit, HF14AAntiCollArgsUnit, DeviceRequiredU
         anti_coll_data = self.cmd.hf14a_get_anti_coll_data()
         if anti_coll_data is None or len(anti_coll_data) == 0:
             print(
-                f"{color_string((CR, f'Slot does not contain any HF 14A config'))}"
+                f"{color_string((CR, 'Slot does not contain any HF 14A config'))}"
             )
             return
         uid = anti_coll_data["uid"]

--- a/software/script/chameleon_cli_unit.py
+++ b/software/script/chameleon_cli_unit.py
@@ -896,6 +896,7 @@ lf_em_410x = lf_em.subgroup("410x", "EM410x commands")
 lf_hid = lf.subgroup("hid", "HID commands")
 lf_hid_prox = lf_hid.subgroup("prox", "HID Prox commands")
 lf_ioprox = lf.subgroup("ioprox", "ioProx commands")
+lf_paradox = lf.subgroup("paradox", "Paradox commands")
 lf_pac = lf.subgroup("pac", "PAC/Stanley commands")
 lf_viking = lf.subgroup("viking", "Viking commands")
 lf_jablotron = lf.subgroup("jablotron", "Jablotron commands")
@@ -6032,6 +6033,74 @@ class LFIOProxEconfig(SlotIndexArgsAndGoUnit, LFIOProxIdArgsUnit):
             print(f"   ID: {color_string((CY, cn))}")
             print(f"   Raw: {color_string((CY, raw8.hex().upper()))}")
 
+
+@lf_paradox.command("econfig")
+class LFParadoxEconfig(SlotIndexArgsAndGoUnit):
+    def args_parser(self) -> ArgumentParserNoExit:
+        parser = ArgumentParserNoExit()
+        parser.description = "Get or set the emulated Paradox credential"
+        self.add_slot_args(parser)
+        parser.add_argument("--fc", type=int, help="Facility code (0..255)", metavar="<int>")
+        parser.add_argument("--cn", type=int, help="Card number (0..65535)", metavar="<int>")
+        return parser
+
+    def on_exec(self, args: argparse.Namespace):
+        do_set = args.fc is not None or args.cn is not None
+        if do_set:
+            if args.fc is None or args.cn is None:
+                raise ArgsParserError("--fc and --cn must be provided together")
+            if not 0 <= args.fc <= 0xff:
+                raise ArgsParserError("--fc must be 0..255")
+            if not 0 <= args.cn <= 0xffff:
+                raise ArgsParserError("--cn must be 0..65535")
+
+            slotinfo = self.cmd.get_slot_info()
+            selected = SlotNumber.from_fw(self.cmd.get_active_slot())
+            lf_tag_type = TagSpecificType(slotinfo[selected - 1]["lf"])
+            if lf_tag_type != TagSpecificType.Paradox:
+                print(f"{color_string((CR, 'WARNING'))}: Slot type is not Paradox.")
+
+            self.cmd.paradox_set_emu_id(struct.pack(">BHx", args.fc, args.cn))
+            fc, cn = args.fc, args.cn
+            action = "SET"
+        else:
+            fc, cn = self.cmd.paradox_get_emu_id()
+            action = "GET"
+
+        print(f" - {action} Paradox credential success.")
+        print(f"   FC: {color_string((CG, fc))}")
+        print(f"   CN: {color_string((CG, cn))}")
+
+
+@lf_paradox.command("read")
+class LFParadoxRead(ReaderRequiredUnit):
+    def args_parser(self) -> ArgumentParserNoExit:
+        parser = ArgumentParserNoExit()
+        parser.description = "Scan a Paradox tag and decode its credential"
+        return parser
+
+    def on_exec(self, args: argparse.Namespace):
+        fc, cn = self.cmd.paradox_scan()
+        print("Paradox")
+        print(f"   FC: {color_string((CG, fc))}")
+        print(f"   CN: {color_string((CG, cn))}")
+
+
+@lf_paradox.command("demod")
+class LFParadoxDemod(DeviceRequiredUnit):
+    def args_parser(self) -> ArgumentParserNoExit:
+        parser = ArgumentParserNoExit()
+        parser.description = "Show raw FSK bits from the most recent Paradox scan"
+        return parser
+
+    def on_exec(self, args: argparse.Namespace):
+        data = self.cmd.paradox_get_last_demod()
+        phase, pairing, errors, bit_count = data[:4]
+        bits = ''.join(f'{byte:08b}' for byte in data[4:])[:bit_count]
+        print(f" Phase: {phase}  pairing: {pairing}  Manchester errors: {errors}")
+        print(f" Bits ({bit_count}): {bits}")
+
+
 def jablotron_card_id(raw_bytes: bytes) -> int:
     """Convert 5 raw Jablotron bytes to decimal card number via BCD."""
     card_id = 0
@@ -6731,6 +6800,10 @@ class HWSlotList(DeviceRequiredUnit):
                     print(f"      {'Facility:':40}{color_string((CG, f'{fc} [0x{fc:02X}]'))}")
                     print(f"      {'ID:':40}{color_string((CY, cn))}")
                     print(f"      {'Raw:':40}{color_string((CY, raw8.hex().upper()))}")
+                if lf_tag_type == TagSpecificType.Paradox:
+                    fc, cn = self.cmd.paradox_get_emu_id()
+                    print(f"      {'Facility:':40}{color_string((CG, fc))}")
+                    print(f"      {'Card number:':40}{color_string((CY, cn))}")
                 if lf_tag_type == TagSpecificType.Viking:
                     id = self.cmd.viking_get_emu_id()
                     print(f"      {'ID:':40}{color_string((CY, id.hex().upper()))}")

--- a/software/script/chameleon_cmd.py
+++ b/software/script/chameleon_cmd.py
@@ -666,6 +666,22 @@ class ChameleonCMD:
         return resp
 
     @expect_response(Status.LF_TAG_OK)
+    def paradox_scan(self):
+        """Read a Paradox facility code and card number."""
+        resp = self.device.send_cmd_sync(Command.PARADOX_SCAN, timeout=10)
+        if resp.status == Status.LF_TAG_OK:
+            resp.parsed = struct.unpack(">BHx", resp.data[:4])
+        return resp
+
+    @expect_response(Status.SUCCESS)
+    def paradox_get_last_demod(self):
+        """Return metadata and raw FSK bits from the most recent scan."""
+        resp = self.device.send_cmd_sync(Command.PARADOX_GET_LAST_DEMOD)
+        if resp.status == Status.SUCCESS:
+            resp.parsed = bytes(resp.data)
+        return resp
+
+    @expect_response(Status.LF_TAG_OK)
     def ioprox_write_to_t55xx(self, id_bytes: bytes):
         """
         Write ioProx card data to a T55XX tag.
@@ -1034,6 +1050,21 @@ class ChameleonCMD:
         resp = self.device.send_cmd_sync(Command.IOPROX_GET_EMU_ID)
         if resp.status == Status.SUCCESS:
             resp.parsed = struct.unpack(">BBH8sBBBB", resp.data[:16])
+        return resp
+
+    @expect_response(Status.SUCCESS)
+    def paradox_set_emu_id(self, credential: bytes):
+        """Set the Paradox facility code and card number on the active slot."""
+        if len(credential) != 4:
+            raise ValueError("The Paradox credential must be exactly 4 bytes")
+        return self.device.send_cmd_sync(Command.PARADOX_SET_EMU_ID, credential)
+
+    @expect_response(Status.SUCCESS)
+    def paradox_get_emu_id(self):
+        """Get the Paradox facility code and card number from the active slot."""
+        resp = self.device.send_cmd_sync(Command.PARADOX_GET_EMU_ID)
+        if resp.status == Status.SUCCESS:
+            resp.parsed = struct.unpack(">BHx", resp.data[:4])
         return resp
 
     @expect_response(Status.SUCCESS)

--- a/software/script/chameleon_enum.py
+++ b/software/script/chameleon_enum.py
@@ -176,9 +176,13 @@ class Command(enum.IntEnum):
     JABLOTRON_GET_EMU_ID = 5011
     IDTECK_SET_EMU_ID = 5012
     IDTECK_GET_EMU_ID = 5013
+    PARADOX_SET_EMU_ID = 5014
+    PARADOX_GET_EMU_ID = 5015
     EM4X05_SCAN = 3030
     EM4X05_READSNIFF = 3032
     LF_SNIFF = 3031
+    PARADOX_SCAN = 3033
+    PARADOX_GET_LAST_DEMOD = 3034
 
 
 @enum.unique
@@ -322,8 +326,7 @@ class TagSpecificType(enum.IntEnum):
     # FSK Tag-Talk-First      200
     HIDProx = 200
     ioProx = 201
-    # AWID
-    # Paradox
+    Paradox = 203  # 202 is reserved for AWID
 
     # PSK Tag-Talk-First      300
     # Indala
@@ -409,6 +412,8 @@ class TagSpecificType(enum.IntEnum):
             return "HIDProx"
         elif self == TagSpecificType.ioProx:
             return "ioProx"
+        elif self == TagSpecificType.Paradox:
+            return "Paradox"
         elif self == TagSpecificType.PAC:
             return "PAC/Stanley"
         elif self == TagSpecificType.Viking:


### PR DESCRIPTION
- adds support for reading and emulating Paradox FSA 125 kHz tags, which use RF/8 and RF/10 subcarriers and RF/50 bit rate. 
- added decoding, encoding, and emulation
- CLI commands: read, econfig, and demod

This PR passes local ruff linter and build checks.