### PR TITLE
ADD hw flash command to CLI

### DIFF
--- a/software/script/chameleon_cli_main.py
+++ b/software/script/chameleon_cli_main.py
@@ -68,12 +68,14 @@ class ChameleonCLI:
 
         :return: current cmd prompt
         """
-        if self.device_com.isOpen():
-            status = color_string((CG, 'USB'))
-        else:
-            status = color_string((CR, 'Offline'))
-
-        return ANSI(f"[{status}] chameleon --> ")
+    if self.device_com.isOpen():
+        ttype = getattr(self.device_com, "transport_type", None)
+        label = {"SERIAL": "USB", "BLE": "BLE", "SOCKET": "TCP"}.get(
+            getattr(ttype, "name", ""), "USB")
+        status = color_string((CG, label))
+    else:
+        status = color_string((CR, 'Offline'))
+    return ANSI(f"[{status}] chameleon --> ")
 
     @staticmethod
     def print_banner():

--- a/software/script/chameleon_cli_main.py
+++ b/software/script/chameleon_cli_main.py
@@ -65,18 +65,17 @@ class ChameleonCLI:
     def get_prompt(self):
         """
         Retrieve the cli prompt
-
         :return: current cmd prompt
         """
-    if self.device_com.isOpen():
-        ttype = getattr(self.device_com, "transport_type", None)
-        label = {"SERIAL": "USB", "BLE": "BLE", "SOCKET": "TCP"}.get(
-            getattr(ttype, "name", ""), "USB")
-        status = color_string((CG, label))
-    else:
-        status = color_string((CR, 'Offline'))
-    return ANSI(f"[{status}] chameleon --> ")
-
+        if self.device_com.isOpen():
+            ttype = getattr(self.device_com, "transport_type", None)
+            label = {"SERIAL": "USB", "BLE": "BLE", "SOCKET": "TCP"}.get(
+                getattr(ttype, "name", ""), "USB")
+            status = color_string((CG, label))
+        else:
+            status = color_string((CR, 'Offline'))
+        return ANSI(f"[{status}] chameleon --> ")
+    
     @staticmethod
     def print_banner():
         """

--- a/software/script/chameleon_cli_unit.py
+++ b/software/script/chameleon_cli_unit.py
@@ -7118,7 +7118,6 @@ class HWDFU(DeviceRequiredUnit):
         # let time for comm thread to send dfu cmd and close port
         time.sleep(0.1)
 
-
 @hw.command("flash")
 class HWFlash(BaseCLIUnit):
     def args_parser(self) -> ArgumentParserNoExit:
@@ -7132,7 +7131,9 @@ class HWFlash(BaseCLIUnit):
         parser.add_argument("--no-enter", action="store_true",
                             help="Skip enter-bootloader; device is already in DFU mode")
         parser.add_argument("-p", "--port", type=str, default=None,
-                            help="DFU serial port (default: auto-detect the 1915:521f device)")
+                            help="Override the upload transport (default: the same transport the "
+                                 "client is connected on). A serial port path, or "
+                                 "'ble' / 'ble:AA:BB:CC:DD:EE:FF' to force BLE DFU (needs bleak)")
         parser.add_argument("--wait", type=float, default=30.0,
                             help="Seconds to wait for the DFU device to appear (default: 30)")
         return parser
@@ -7148,69 +7149,78 @@ class HWFlash(BaseCLIUnit):
             print(color_string((CR, f"Invalid DFU package: {e}")))
             return
 
-        # Enter bootloader unless told the device is already in DFU.
-        already_dfu = chameleon_dfu.find_dfu_port() is not None
-        if not args.no_enter and not already_dfu:
-            if not self.device_com.isOpen():
-                print("Please connect to chameleon device first (use 'hw connect'), "
-                      "or pass --no-enter if it is already in DFU mode.")
-                return
-            print("Application restarting into DFU mode...")
-            self.cmd.enter_bootloader()
-            time.sleep(0.1)
+        # Pick the upload transport. An explicit --port overrides; otherwise
+        # inherit whatever the client is already connected on (USB serial or
+        # BLE). DFU entry rides that same link; the device then re-advertises
+        # USB DFU (1915:521f) and/or the BLE DFU service (0xFE59).
+        override = args.port
+        ble_address = None
+        serial_port = None
+        if override is not None and override.lower().startswith("ble"):
+            use_ble = True
+            ble_address = override.split(":", 1)[1] if ":" in override else None
+        elif override is not None:
+            use_ble = False
+            serial_port = override
+        else:
+            ttype = getattr(self.device_com, "transport_type", None)
+            use_ble = getattr(ttype, "name", "") == "BLE"
 
-        # Locate the DFU device.
-        port = args.port
-        if port is None:
-            print("Waiting for DFU device...")
-            port = chameleon_dfu.wait_for_dfu_port(timeout=args.wait)
-            if port is None:
-                print(color_string((CR, "DFU device (1915:521f) not found. "
-                                        "Put the device in DFU mode and retry.")))
-                return
-        print(f"Flashing {os.path.basename(args.file)} via {port}")
+        # Enter bootloader unless the device is already in DFU or told to skip.
+        if not args.no_enter:
+            already_dfu = (not use_ble) and chameleon_dfu.find_dfu_port() is not None
+            if not already_dfu:
+                if not self.device_com.isOpen():
+                    print("Please connect to chameleon device first (use 'hw connect'), "
+                          "or pass --no-enter if it is already in DFU mode.")
+                    return
+                print("Application restarting into DFU mode...")
+                self.cmd.enter_bootloader()
+                time.sleep(0.1)
+
+        # Release the app link before the upload (frees the serial port / BLE
+        # central so the DFU transport can take it).
+        if self.device_com.isOpen():
+            self.device_com.close()
+
+        # Build the upload transport.
+        try:
+            if use_ble:
+                print("Scanning for DFU device (BLE, service 0xFE59)...")
+                transport = chameleon_dfu.ble_transport(address=ble_address,
+                                                        scan_timeout=args.wait)
+                where = f"BLE {ble_address}" if ble_address else "BLE"
+            else:
+                port = serial_port
+                if port is None:
+                    print("Waiting for DFU device...")
+                    port = chameleon_dfu.wait_for_dfu_port(timeout=args.wait)
+                    if port is None:
+                        print(color_string((CR, "DFU device (1915:521f) not found. "
+                                                "Put the device in DFU mode and retry.")))
+                        return
+                transport = chameleon_dfu.serial_transport(port)
+                where = port
+        except chameleon_dfu.DFUError as e:
+            print(color_string((CR, f"Could not open DFU transport: {e}")))
+            return
+
+        print(f"Flashing {os.path.basename(args.file)} via {where}")
 
         def progress(pct):
             print(f"\r - Uploading: {pct:3d}%", end="", flush=True)
 
         try:
-            chameleon_dfu.flash_package(dat, bin_, port, progress=progress)
+            chameleon_dfu.flash_package(dat, bin_, transport, progress=progress)
         except chameleon_dfu.DFUError as e:
             print()
             print(color_string((CR, f"Flash failed: {e}")))
             return
+        finally:
+            transport.close()
         print()
         print(color_string((CG, " - Firmware flashed. Device will reboot.")))
         time.sleep(0.5)
-
-
-@hw_settings.command("animation")
-class HWSettingsAnimation(DeviceRequiredUnit):
-    def args_parser(self) -> ArgumentParserNoExit:
-        parser = ArgumentParserNoExit()
-        parser.description = "Get or change current animation mode value"
-        mode_names = [m.name for m in list(AnimationMode)]
-        help_str = "Mode: " + ", ".join(mode_names)
-        parser.add_argument(
-            "-m",
-            "--mode",
-            type=str,
-            required=False,
-            help=help_str,
-            metavar="MODE",
-            choices=mode_names,
-        )
-        return parser
-
-    def on_exec(self, args: argparse.Namespace):
-        if args.mode is not None:
-            mode = AnimationMode[args.mode]
-            self.cmd.set_animation_mode(mode)
-            print("Animation mode change success.")
-            print(color_string((CY, "Do not forget to store your settings in flash!")))
-        else:
-            print(AnimationMode(self.cmd.get_animation_mode()))
-
 
 @hw_settings.command("sleeptimeout")
 class HWSettingsSleepTimeout(DeviceRequiredUnit):

--- a/software/script/chameleon_cli_unit.py
+++ b/software/script/chameleon_cli_unit.py
@@ -24,6 +24,7 @@ import hardnested_utils
 
 import chameleon_com
 import chameleon_cmd
+import chameleon_dfu
 from chameleon_utils import (
     ArgumentParserNoExit,
     ArgsParserError,
@@ -7104,6 +7105,71 @@ class HWDFU(DeviceRequiredUnit):
         print(" - Enter success @.@~")
         # let time for comm thread to send dfu cmd and close port
         time.sleep(0.1)
+
+
+@hw.command("flash")
+class HWFlash(BaseCLIUnit):
+    def args_parser(self) -> ArgumentParserNoExit:
+        parser = ArgumentParserNoExit()
+        parser.description = (
+            "Flash a DFU firmware package (.zip) to the device over Secure DFU. "
+            "Enters bootloader mode automatically, then uploads with no external "
+            "tools required (no nrfutil)."
+        )
+        parser.add_argument("file", type=str, help="Path to the DFU package .zip")
+        parser.add_argument("--no-enter", action="store_true",
+                            help="Skip enter-bootloader; device is already in DFU mode")
+        parser.add_argument("-p", "--port", type=str, default=None,
+                            help="DFU serial port (default: auto-detect the 1915:521f device)")
+        parser.add_argument("--wait", type=float, default=30.0,
+                            help="Seconds to wait for the DFU device to appear (default: 30)")
+        return parser
+
+    def on_exec(self, args: argparse.Namespace):
+        # Unpack first so a bad package fails before we touch the device.
+        try:
+            dat, bin_ = chameleon_dfu.unpack_dfu_zip(args.file)
+        except FileNotFoundError:
+            print(color_string((CR, f"File not found: {args.file}")))
+            return
+        except chameleon_dfu.DFUError as e:
+            print(color_string((CR, f"Invalid DFU package: {e}")))
+            return
+
+        # Enter bootloader unless told the device is already in DFU.
+        already_dfu = chameleon_dfu.find_dfu_port() is not None
+        if not args.no_enter and not already_dfu:
+            if not self.device_com.isOpen():
+                print("Please connect to chameleon device first (use 'hw connect'), "
+                      "or pass --no-enter if it is already in DFU mode.")
+                return
+            print("Application restarting into DFU mode...")
+            self.cmd.enter_bootloader()
+            time.sleep(0.1)
+
+        # Locate the DFU device.
+        port = args.port
+        if port is None:
+            print("Waiting for DFU device...")
+            port = chameleon_dfu.wait_for_dfu_port(timeout=args.wait)
+            if port is None:
+                print(color_string((CR, "DFU device (1915:521f) not found. "
+                                        "Put the device in DFU mode and retry.")))
+                return
+        print(f"Flashing {os.path.basename(args.file)} via {port}")
+
+        def progress(pct):
+            print(f"\r - Uploading: {pct:3d}%", end="", flush=True)
+
+        try:
+            chameleon_dfu.flash_package(dat, bin_, port, progress=progress)
+        except chameleon_dfu.DFUError as e:
+            print()
+            print(color_string((CR, f"Flash failed: {e}")))
+            return
+        print()
+        print(color_string((CG, " - Firmware flashed. Device will reboot.")))
+        time.sleep(0.5)
 
 
 @hw_settings.command("animation")

--- a/software/script/chameleon_dfu.py
+++ b/software/script/chameleon_dfu.py
@@ -1,0 +1,298 @@
+"""
+Self-contained Nordic Secure DFU (serial/USB-CDC) controller.
+
+Speaks the nRF5 SDK Secure DFU serial transport directly over pyserial, so
+`hw flash` can push a DFU package without nrfutil or any external tool.
+
+The protocol here mirrors the implementation the ChameleonUltraGUI / Sailfish
+frontends use against this same bootloader (SLIP framing, PRN=0, Get Serial
+MTU with a 2051-byte fallback, object select/create/write/checksum/execute,
+running standard CRC-32). Transport only: the package is unpacked by the
+caller and the bootloader validates the signature.
+"""
+
+import struct
+import time
+import zlib
+
+import serial
+
+
+# --- Secure DFU opcodes (nRF5 SDK nrf_dfu_serial / dfu_transport_serial) -----
+class DfuOp:
+    CREATE_OBJECT = 0x01
+    SET_PRN = 0x02
+    CALC_CHECKSUM = 0x03
+    EXECUTE = 0x04
+    READ_ERROR = 0x05
+    SELECT_OBJECT = 0x06     # "read object" / select
+    GET_SERIAL_MTU = 0x07
+    WRITE_OBJECT = 0x08
+    PING = 0x09
+    RESPONSE = 0x60
+
+
+# --- Secure DFU result codes -------------------------------------------------
+DFU_RESULT = {
+    0x00: "invalid code",
+    0x01: "success",
+    0x02: "opcode not supported",
+    0x03: "invalid parameter",
+    0x04: "insufficient resources",
+    0x05: "invalid object",
+    0x07: "unsupported object type",
+    0x08: "operation not permitted",
+    0x0A: "operation failed",
+    0x0B: "extended error",
+}
+
+# Object types used by Secure DFU.
+OBJ_TYPE_COMMAND = 0x01   # init packet (.dat)
+OBJ_TYPE_DATA = 0x02      # firmware image (.bin)
+
+# Nordic USB DFU VID/PID for the Chameleon bootloader.
+DFU_VID = 0x1915
+DFU_PID = 0x521F
+
+
+class DFUError(Exception):
+    pass
+
+
+class DFUTransferError(DFUError):
+    """Recoverable mid-transfer error (offset/CRC mismatch) -> retry object."""
+
+
+# --- SLIP (RFC 1055) ---------------------------------------------------------
+_SLIP_END = 0xC0
+_SLIP_ESC = 0xDB
+_SLIP_ESC_END = 0xDC
+_SLIP_ESC_ESC = 0xDD
+
+
+def slip_encode(data: bytes) -> bytes:
+    out = bytearray()
+    for b in data:
+        if b == _SLIP_END:
+            out += bytes((_SLIP_ESC, _SLIP_ESC_END))
+        elif b == _SLIP_ESC:
+            out += bytes((_SLIP_ESC, _SLIP_ESC_ESC))
+        else:
+            out.append(b)
+    out.append(_SLIP_END)
+    return bytes(out)
+
+
+def slip_decode(data: bytes) -> bytes:
+    out = bytearray()
+    esc = False
+    for b in data:
+        if esc:
+            if b == _SLIP_ESC_END:
+                out.append(_SLIP_END)
+            elif b == _SLIP_ESC_ESC:
+                out.append(_SLIP_ESC)
+            else:
+                # protocol violation; drop the frame
+                return b""
+            esc = False
+        elif b == _SLIP_ESC:
+            esc = True
+        elif b == _SLIP_END:
+            break
+        else:
+            out.append(b)
+    return bytes(out)
+
+
+class DFUSerial:
+    """Secure DFU over a raw serial port (the bootloader's USB CDC ACM)."""
+
+    def __init__(self, port: str, timeout: float = 20.0):
+        self.timeout = timeout
+        self.mtu = 0
+        self.prn = 0
+        self.serial = serial.Serial(port=port, baudrate=115200, timeout=timeout)
+
+    def close(self):
+        try:
+            self.serial.close()
+        except Exception:
+            pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        self.close()
+
+    # -- framed request/response --------------------------------------------
+    def _read_packet(self) -> bytes:
+        """Read one SLIP frame (up to the END byte) and decode it."""
+        raw = bytearray()
+        deadline = time.time() + self.timeout
+        while time.time() < deadline:
+            b = self.serial.read(1)
+            if not b:
+                continue
+            raw.append(b[0])
+            if b[0] == _SLIP_END and len(raw) > 1:
+                return slip_decode(bytes(raw))
+        raise DFUError("timeout waiting for DFU response")
+
+    def send_cmd(self, opcode: int, data: bytes = b"") -> bytes:
+        self.serial.reset_input_buffer()
+        self.serial.write(slip_encode(bytes((opcode,)) + data))
+        resp = self._read_packet()
+        if len(resp) < 3 or resp[0] != DfuOp.RESPONSE:
+            raise DFUError(f"malformed DFU response: {resp.hex()}")
+        if resp[1] != opcode:
+            raise DFUTransferError(
+                f"unexpected DFU response opcode 0x{resp[1]:02x} (sent 0x{opcode:02x})")
+        result = resp[2]
+        if result == 0x01:  # success
+            return resp[3:]
+        if result == 0x0B and len(resp) > 3:  # extended error
+            raise DFUError(f"DFU extended error 0x{resp[3]:02x}")
+        raise DFUError(f"DFU error: {DFU_RESULT.get(result, hex(result))}")
+
+    # -- primitives ---------------------------------------------------------
+    def set_prn(self, prn: int = 0):
+        self.prn = prn
+        self.send_cmd(DfuOp.SET_PRN, struct.pack("<H", prn))
+
+    def get_mtu(self) -> int:
+        try:
+            resp = self.send_cmd(DfuOp.GET_SERIAL_MTU)
+            self.mtu = struct.unpack("<H", resp[:2])[0]
+        except DFUError:
+            self.mtu = 2051
+        if self.mtu == 0:
+            self.mtu = 2051
+        return self.mtu
+
+    def select_object(self, obj_type: int):
+        resp = self.send_cmd(DfuOp.SELECT_OBJECT, bytes((obj_type,)))
+        max_size, offset, crc = struct.unpack("<III", resp[:12])
+        return max_size, offset, crc
+
+    def create_object(self, obj_type: int, size: int):
+        self.send_cmd(DfuOp.CREATE_OBJECT, bytes((obj_type,)) + struct.pack("<I", size))
+
+    def calculate_checksum(self):
+        resp = self.send_cmd(DfuOp.CALC_CHECKSUM)
+        offset, crc = struct.unpack("<II", resp[:8])
+        return offset, crc
+
+    def execute(self):
+        self.send_cmd(DfuOp.EXECUTE)
+
+    # -- transfer -----------------------------------------------------------
+    def _write_object(self, chunk: bytes, crc: int, offset: int):
+        """Stream one create-object window; validate offset+CRC at the end.
+
+        With PRN=0 there are no intermediate receipts, so we only checksum
+        once per object window (matches the reference flasher).
+        """
+        # SLIP worst case doubles every byte, and one byte is the opcode:
+        # keep each written frame's payload within (mtu-1)//2 - 1.
+        step = max(1, (self.mtu - 1) // 2 - 1)
+        for i in range(0, len(chunk), step):
+            part = chunk[i:i + step]
+            self.serial.write(slip_encode(bytes((DfuOp.WRITE_OBJECT,)) + part))
+            offset += len(part)
+            crc = zlib.crc32(part, crc) & 0xFFFFFFFF
+        recv_offset, recv_crc = self.calculate_checksum()
+        if recv_offset != offset:
+            raise DFUTransferError(f"offset mismatch: expected {offset}, got {recv_offset}")
+        if recv_crc != crc:
+            raise DFUTransferError(
+                f"CRC mismatch: expected 0x{crc:08x}, got 0x{recv_crc:08x}")
+        return crc
+
+    def flash_object(self, obj_type: int, data: bytes, progress=None, retries: int = 10):
+        """Program one Secure DFU object (init packet or firmware image)."""
+        max_size, _, _ = self.select_object(obj_type)
+        if max_size == 0:
+            max_size = len(data) or 1
+        crc = 0
+        sent = 0
+        for offset in range(0, len(data), max_size):
+            window = data[offset:offset + max_size]
+            crc_backup = crc
+            for attempt in range(retries):
+                self.create_object(obj_type, len(window))
+                try:
+                    crc = self._write_object(window, crc, offset)
+                except DFUTransferError:
+                    # re-select to resync and retry this window
+                    self.select_object(obj_type)
+                    crc = crc_backup
+                    continue
+                self.execute()
+                break
+            else:
+                raise DFUError(f"unable to program object at offset {offset}")
+            sent += len(window)
+            if progress:
+                progress(min(100, round(sent * 100 / len(data))))
+
+
+def find_dfu_port():
+    """Return the serial device path of a Chameleon in DFU mode, or None."""
+    import serial.tools.list_ports as list_ports
+    for p in list_ports.comports():
+        if p.vid == DFU_VID and p.pid == DFU_PID:
+            return p.device
+    return None
+
+
+def wait_for_dfu_port(timeout: float = 30.0, poll: float = 0.25):
+    """Block until the DFU USB device enumerates; return its port path."""
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        port = find_dfu_port()
+        if port:
+            # give the CDC endpoint a moment to be openable after enumeration
+            time.sleep(0.3)
+            return port
+        time.sleep(poll)
+    return None
+
+
+def unpack_dfu_zip(path: str):
+    """Extract (init_packet, firmware_image) from a Nordic DFU package .zip.
+
+    Chameleon packages name the members application.dat / application.bin.
+    Falls back to the manifest.json if the names ever differ.
+    """
+    import json
+    import zipfile
+
+    with zipfile.ZipFile(path) as zf:
+        names = set(zf.namelist())
+        dat_name, bin_name = "application.dat", "application.bin"
+        if dat_name not in names or bin_name not in names:
+            if "manifest.json" in names:
+                manifest = json.loads(zf.read("manifest.json"))
+                app = manifest.get("manifest", {}).get("application", {})
+                dat_name = app.get("dat_file", dat_name)
+                bin_name = app.get("bin_file", bin_name)
+            else:
+                raise DFUError(
+                    "not a Chameleon DFU package (no application.dat/.bin or manifest.json)")
+        return zf.read(dat_name), zf.read(bin_name)
+
+
+def flash_package(dat: bytes, bin_: bytes, port: str, progress=None, timeout: float = 20.0):
+    """Run the full Secure DFU sequence against a device already in DFU mode."""
+    if not dat or not bin_:
+        raise DFUError("empty init packet or firmware image")
+    dfu = DFUSerial(port, timeout=timeout)
+    try:
+        dfu.set_prn(0)
+        dfu.get_mtu()
+        dfu.flash_object(OBJ_TYPE_COMMAND, dat, progress)   # init packet
+        dfu.flash_object(OBJ_TYPE_DATA, bin_, progress)     # firmware
+    finally:
+        dfu.close()


### PR DESCRIPTION
Add hw flash command to chameleon main cli

hw flash -h
usage: hw flash [-h] [--no-enter] [-p PORT] [--wait WAIT] file

Flash a DFU firmware package (.zip) to the device over Secure DFU. Enters bootloader mode automatically, then uploads with no external tools required (no nrfutil).

positional arguments:
  file             Path to the DFU package .zip

options:
  -h, --help       show this help message and exit
  --no-enter       Skip enter-bootloader; device is already in DFU mode
  -p, --port PORT  DFU serial port (default: auto-detect the 1915:521f device)
  --wait WAIT      Seconds to wait for the DFU device to appear (default: 30)