### PR TITLE
Fix ISO14443-4 RX truncation of frames ≥32 bytes (unwrap_frame uint8_t return)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project uses the changelog in accordance with [keepchangelog](http://keepachangelog.com/). Please use this to write notable changes, which is not the same as git commit log...
 
 ## [unreleased][unreleased]
+ - Fixed ISO14443-4 (T=CL) tag emulation silently truncating any received command of 32+ bytes (e.g. an EMV GPO with a full PDOL): `nfc_tag_14a_unwrap_frame` returned the data-bit count as `uint8_t`, wrapping it mod 256 (@whitewhidow)
 
 ## [v2.2.0][2026-07-04]
  - Added Jablotron LF protocol support: read, emulate and T55xx clone (@midlan)

--- a/firmware/application/src/rfid/nfctag/hf/nfc_14a.c
+++ b/firmware/application/src/rfid/nfctag/hf/nfc_14a.c
@@ -212,7 +212,12 @@ uint8_t nfc_tag_14a_wrap_frame(const uint8_t *pbtTx, const size_t szTxBits, cons
 *          pbtRxPar: The buffer of the bitstream Store after the packaging, the coupling school inspection area
 * @retval :The data length of the bitstream packaging, note that the length of the data area is the length of the data area.retval / 8
 */
-uint8_t nfc_tag_14a_unwrap_frame(const uint8_t *pbtFrame, const size_t szFrameBits, uint8_t *pbtRx, uint8_t *pbtRxPar) {
+/* Return type MUST be 16-bit: this returns the de-parity'd data-bit count,
+ * which exceeds 255 for any received frame of >=32 bytes. A uint8_t return
+ * wraps it mod 256, silently truncating every large reader->tag command
+ * (e.g. an ISO14443-4 APDU of 32+ bytes: a 44-byte frame -> 352 data bits
+ * -> 352 & 0xFF = 96 bits = 12 bytes reached the caller). */
+uint16_t nfc_tag_14a_unwrap_frame(const uint8_t *pbtFrame, const size_t szFrameBits, uint8_t *pbtRx, uint8_t *pbtRxPar) {
     uint8_t btFrame;
     uint8_t btData;
     uint8_t uiBitPos;

--- a/firmware/application/src/rfid/nfctag/hf/nfc_14a.h
+++ b/firmware/application/src/rfid/nfctag/hf/nfc_14a.h
@@ -124,7 +124,7 @@ bool nfc_tag_14a_checks_crc(uint8_t *pbtData, size_t szLen);
 
 // 14A frame combination
 uint8_t nfc_tag_14a_wrap_frame(const uint8_t *pbtTx, const size_t szTxBits, const uint8_t *pbtTxPar, uint8_t *pbtFrame);
-uint8_t nfc_tag_14a_unwrap_frame(const uint8_t *pbtFrame, const size_t szFrameBits, uint8_t *pbtRx, uint8_t *pbtRxPar);
+uint16_t nfc_tag_14a_unwrap_frame(const uint8_t *pbtFrame, const size_t szFrameBits, uint8_t *pbtRx, uint8_t *pbtRxPar);
 
 // 14A communication control
 void nfc_tag_14a_sense_switch(bool enable);


### PR DESCRIPTION
## Problem

`nfc_tag_14a_unwrap_frame()` returns the de-parity'd **data-bit count**, but its return type is `uint8_t`. For any received frame of **32 bytes or more** that count exceeds 255, so the return value **wraps modulo 256** — silently truncating the frame that `nfc_tag_14a_data_process()` then processes.

Example: a 44-byte reader→tag command is 352 data bits. `352 & 0xFF = 96` bits = **12 bytes**, so only the first 12 bytes reach the tag/APDU layer.

This breaks any ISO14443-4 (T=CL) tag emulation that receives a command of 32+ bytes. A real-world trigger is an EMV **GET PROCESSING OPTIONS** carrying a full PDOL (~40 bytes): the emulated card receives a wrong-length command and the real terminal/card answers `67 00`. Small commands (SELECT, empty-PDOL GPO, etc.) are unaffected, which is why this hid for so long.

## Root cause

```c
uint8_t nfc_tag_14a_unwrap_frame(..., const size_t szFrameBits, ...) {
    ...
    size_t szRxBits = szFrameBits - (szFrameBits / 9);   // computed correctly in size_t
    ...
    return szRxBits;   // truncated to 8 bits on return
}
```

The internal math uses `size_t`; only the **return type** truncates.

## Fix

Change the return type to `uint16_t` (`.c` and `.h`). One-line change; `MAX_NFC_RX_BUFFER_SIZE` is 257 so 16-bit is sufficient.

## Verification (nRF52840 hardware)

Reproduced deterministically with two Chameleon Ultras — one as an RC522 reader sending commands of increasing size to the other running the NFCT tag emulator, reading back the received length:

| frame size | received (before) | received (after) |
|---|---|---|
| ≤ 28 bytes | full | full |
| 32 | 0 (`32 mod 32`) | full |
| 44 | 12 (`44 mod 32`) | full |
| 56 | 24 (`56 mod 32`) | full |

The raw `NFCT->RXD.AMOUNT` register was **correct at every size** (e.g. 396 for a 44-byte frame) — only the truncated `uint8_t` return corrupted the length. After the fix, a full-PDOL EMV GPO (and any 32+ byte command) reaches the tag intact.
